### PR TITLE
Feature/global timeout

### DIFF
--- a/pkg/k8s/k8s_pod.go
+++ b/pkg/k8s/k8s_pod.go
@@ -77,17 +77,18 @@ func NewVolume(path, size string, owner int64) *Volume {
 
 // PodConfig contains the specifications for creating a new Pod object
 type PodConfig struct {
-	Namespace     string            // Kubernetes namespace of the Pod
-	Name          string            // Name to assign to the Pod
-	Labels        map[string]string // Labels to apply to the Pod
-	Image         string            // Name of the Docker image to use for the container
-	Command       []string          // Command to run in the container
-	Args          []string          // Arguments to pass to the command in the container
-	Env           map[string]string // Environment variables to set in the container
-	Volumes       []*Volume         // Volumes to mount in the Pod
-	MemoryRequest string            // Memory request for the container
-	MemoryLimit   string            // Memory limit for the container
-	CPURequest    string            // CPU request for the container
+	Namespace          string            // Kubernetes namespace of the Pod
+	Name               string            // Name to assign to the Pod
+	Labels             map[string]string // Labels to apply to the Pod
+	Image              string            // Name of the Docker image to use for the container
+	Command            []string          // Command to run in the container
+	Args               []string          // Arguments to pass to the command in the container
+	Env                map[string]string // Environment variables to set in the container
+	Volumes            []*Volume         // Volumes to mount in the Pod
+	MemoryRequest      string            // Memory request for the container
+	MemoryLimit        string            // Memory limit for the container
+	CPURequest         string            // CPU request for the container
+	ServiceAccountName string            // ServiceAccount to assign to Pod
 }
 
 // ReplacePodWithGracePeriod replaces a pod in the given namespace and returns the new Pod object with a grace period.
@@ -406,8 +407,8 @@ func preparePodSpec(spec PodConfig, init bool) (v1.PodSpec, error) {
 	}
 
 	podSpec := v1.PodSpec{
-
-		InitContainers: initContainers,
+		ServiceAccountName: spec.ServiceAccountName,
+		InitContainers:     initContainers,
 		Containers: []v1.Container{
 			{
 				Name:         name,

--- a/pkg/k8s/k8s_role.go
+++ b/pkg/k8s/k8s_role.go
@@ -1,0 +1,56 @@
+package k8s
+
+import (
+	"context"
+	"fmt"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"time"
+)
+
+// CreateRole creates a role
+func CreateRole(name, namespace string, labels map[string]string, apiGroups, resources, verbs []string) error {
+
+	role := &rbacv1.Role{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels:    labels,
+		},
+		Rules: []rbacv1.PolicyRule{
+			{
+				APIGroups: apiGroups,
+				Resources: resources,
+				Verbs:     verbs,
+			},
+		},
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+
+	if !IsInitialized() {
+		return fmt.Errorf("knuu is not initialized")
+	}
+	if _, err := Clientset().RbacV1().Roles(namespace).Create(ctx, role, metav1.CreateOptions{}); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// DeleteRole deletes a role
+func DeleteRole(name, namespace string) error {
+
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+
+	if !IsInitialized() {
+		return fmt.Errorf("knuu is not initialized")
+	}
+	if err := Clientset().RbacV1().Roles(namespace).Delete(ctx, name, metav1.DeleteOptions{}); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/pkg/k8s/k8s_rolebinding.go
+++ b/pkg/k8s/k8s_rolebinding.go
@@ -1,0 +1,60 @@
+package k8s
+
+import (
+	"context"
+	"fmt"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"time"
+)
+
+// CreateRoleBinding creates a roleBinding
+func CreateRoleBinding(name, namespace string, labels map[string]string, role, serviceAccount string) error {
+
+	roleBinding := &rbacv1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels:    labels,
+		},
+		RoleRef: rbacv1.RoleRef{
+			Kind: "Role",
+			Name: role,
+		},
+		Subjects: []rbacv1.Subject{
+			{
+				Kind:      "ServiceAccount",
+				Name:      serviceAccount,
+				Namespace: namespace,
+			},
+		},
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+
+	if !IsInitialized() {
+		return fmt.Errorf("knuu is not initialized")
+	}
+	if _, err := Clientset().RbacV1().RoleBindings(namespace).Create(ctx, roleBinding, metav1.CreateOptions{}); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// DeleteRoleBinding deletes a roleBinding
+func DeleteRoleBinding(name, namespace string) error {
+
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+
+	if !IsInitialized() {
+		return fmt.Errorf("knuu is not initialized")
+	}
+	if err := Clientset().RbacV1().RoleBindings(namespace).Delete(ctx, name, metav1.DeleteOptions{}); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/pkg/k8s/k8s_serviceaccount.go
+++ b/pkg/k8s/k8s_serviceaccount.go
@@ -1,0 +1,49 @@
+package k8s
+
+import (
+	"context"
+	"fmt"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"time"
+)
+
+// CreateServiceAccount creates a service account
+func CreateServiceAccount(name, namespace string, labels map[string]string) error {
+
+	serviceAccount := &v1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels:    labels,
+		},
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+
+	if !IsInitialized() {
+		return fmt.Errorf("knuu is not initialized")
+	}
+	if _, err := Clientset().CoreV1().ServiceAccounts(namespace).Create(ctx, serviceAccount, metav1.CreateOptions{}); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// DeleteServiceAccount deletes a service account
+func DeleteServiceAccount(name, namespace string) error {
+
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+
+	if !IsInitialized() {
+		return fmt.Errorf("knuu is not initialized")
+	}
+	if err := Clientset().CoreV1().ServiceAccounts(namespace).Delete(ctx, name, metav1.DeleteOptions{}); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/pkg/knuu/instance_helper.go
+++ b/pkg/knuu/instance_helper.go
@@ -126,17 +126,18 @@ func (i *Instance) deployPod() error {
 
 	// Generate the pod configuration
 	podConfig := k8s.PodConfig{
-		Namespace:     k8s.Namespace(),
-		Name:          i.k8sName,
-		Labels:        labels,
-		Image:         imageName,
-		Command:       i.command,
-		Args:          i.args,
-		Env:           i.env,
-		Volumes:       i.volumes,
-		MemoryRequest: i.memoryRequest,
-		MemoryLimit:   i.memoryLimit,
-		CPURequest:    i.cpuRequest,
+		Namespace:          k8s.Namespace(),
+		Name:               i.k8sName,
+		Labels:             labels,
+		Image:              imageName,
+		Command:            i.command,
+		Args:               i.args,
+		Env:                i.env,
+		Volumes:            i.volumes,
+		MemoryRequest:      i.memoryRequest,
+		MemoryLimit:        i.memoryLimit,
+		CPURequest:         i.cpuRequest,
+		ServiceAccountName: i.serviceAccountName,
 	}
 
 	statefulSetConfig := k8s.StatefulSetConfig{

--- a/pkg/knuu/knuu.go
+++ b/pkg/knuu/knuu.go
@@ -88,7 +88,7 @@ func handleTimeout() error {
 	if err != nil {
 		return fmt.Errorf("cannot create instance: %s", err)
 	}
-	// FIXME: use supported kubernetes version images (use of latest could break)
+	// FIXME: use supported kubernetes version images (use of latest could break) (https://github.com/celestiaorg/knuu/issues/116)
 	if err := instance.SetImage("docker.io/bitnami/kubectl:latest"); err != nil {
 		return fmt.Errorf("cannot set image: %s", err)
 	}

--- a/pkg/knuu/knuu.go
+++ b/pkg/knuu/knuu.go
@@ -99,6 +99,7 @@ func handleTimeout() error {
 
 	// command to wait for timeout and delete all resources with the identifier
 	var command = []string{"sh", "-c"}
+	// Command runs in-cluster to delete resources post-test. Chosen for simplicity over a separate Go app.
 	cmd := fmt.Sprintf("sleep %d && kubectl delete all,pvc,netpol,roles,serviceaccounts,rolebindings -l test-run-id=%s -n %s --wait=false", timeoutSeconds, identifier, k8s.Namespace())
 	command = append(command, cmd)
 

--- a/pkg/knuu/preloader.go
+++ b/pkg/knuu/preloader.go
@@ -87,7 +87,10 @@ func (p *Preloader) preloadImages() error {
 	})
 
 	labels := map[string]string{
-		"app": p.k8sName,
+		"app":                          p.k8sName,
+		"k8s.kubernetes.io/managed-by": "knuu",
+		"test-run-id":                  identifier,
+		"test-started":                 startTime,
 	}
 
 	exists, err := k8s.DaemonSetExists(k8s.Namespace(), p.k8sName)


### PR DESCRIPTION
Introduces a new env variable `KNUU_TIMEOUT` with the default of `1h`, which will delete all resources that are still running after that time for that specific test run.

Resolves https://github.com/celestiaorg/knuu/issues/84, resolves https://github.com/celestiaorg/knuu/issues/78, resolves https://github.com/celestiaorg/knuu/issues/18

<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->

## Checklist

<!-- 
Please complete the checklist to ensure that the PR is ready to be reviewed.

IMPORTANT:
PRs should be left in Draft until the below checklist is completed.
-->

- [ ] New and updated code has appropriate documentation
- [ ] New and updated code has new and/or updated testing
- [ ] Required CI checks are passing
- [ ] Visual proof for any user facing features like CLI or documentation updates
- [ ] Linked issues closed with keywords
