### PR TITLE
bugfix: proper cleanup with timeout handler

### DIFF
--- a/pkg/knuu/instance_type.go
+++ b/pkg/knuu/instance_type.go
@@ -7,6 +7,7 @@ type InstanceType int
 const (
 	BasicInstance InstanceType = iota
 	ExecutorInstance
+	TimeoutHandlerInstance
 )
 
 // String returns the string representation of the type
@@ -14,5 +15,5 @@ func (s InstanceType) String() string {
 	if s < 0 || s > 2 {
 		return "Unknown"
 	}
-	return [...]string{"BasicInstance", "ExecutorInstance"}[s]
+	return [...]string{"BasicInstance", "ExecutorInstance", "TimeoutHandlerInstance"}[s]
 }

--- a/pkg/knuu/knuu.go
+++ b/pkg/knuu/knuu.go
@@ -102,9 +102,9 @@ func handleTimeout() error {
 	var command = []string{"sh", "-c"}
 	// Command runs in-cluster to delete resources post-test. Chosen for simplicity over a separate Go app.
 	wait := fmt.Sprintf("sleep %d", timeoutSeconds)
-	deleteAllTimeOutType := fmt.Sprintf("kubectl get all,pvc,netpol,roles,serviceaccounts,rolebindings -l test-run-id=%s -n %s -o json | jq -r '.items[] | select(.metadata.labels.type != \"%s\") | \"\\(.kind)/\\(.metadata.name)\"' | xargs kubectl delete -n %s", identifier, k8s.Namespace(), TimeoutHandlerInstance.String(), k8s.Namespace())
+	deleteAllButTimeOutType := fmt.Sprintf("kubectl get all,pvc,netpol,roles,serviceaccounts,rolebindings -l test-run-id=%s -n %s -o json | jq -r '.items[] | select(.metadata.labels.type != \"%s\") | \"\\(.kind)/\\(.metadata.name)\"' | xargs kubectl delete -n %s", identifier, k8s.Namespace(), TimeoutHandlerInstance.String(), k8s.Namespace())
 	deleteAll := fmt.Sprintf("kubectl delete all,pvc,netpol,roles,serviceaccounts,rolebindings -l test-run-id=%s -n %s", identifier, k8s.Namespace())
-	cmd := fmt.Sprintf("%s && %s && %s", wait, deleteAllTimeOutType, deleteAll)
+	cmd := fmt.Sprintf("%s && %s && %s", wait, deleteAllButTimeOutType, deleteAll)
 	command = append(command, cmd)
 
 	if err := instance.SetCommand(command...); err != nil {


### PR DESCRIPTION
Sometimes not all resources get deleted because the timeout handler is deleted before everything can be deleted.

This PR changes the timeout handler command in a way that it first deletes all other resources, and once this is done, it deletes itself.

<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->

## Checklist

<!-- 
Please complete the checklist to ensure that the PR is ready to be reviewed.

IMPORTANT:
PRs should be left in Draft until the below checklist is completed.
-->

- [ ] New and updated code has appropriate documentation
- [ ] New and updated code has new and/or updated testing
- [ ] Required CI checks are passing
- [ ] Visual proof for any user facing features like CLI or documentation updates
- [ ] Linked issues closed with keywords
