### PR TITLE
fix: execute command with a shell

### DIFF
--- a/pkg/knuu/instance.go
+++ b/pkg/knuu/instance.go
@@ -10,6 +10,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 )
 
@@ -272,7 +273,8 @@ func (i *Instance) ExecuteCommand(command ...string) (string, error) {
 		if err != nil {
 			return "", fmt.Errorf("error getting pod from statefulset '%s': %v", i.k8sName, err)
 		}
-		output, err := k8s.RunCommandInPod(k8s.Namespace(), pod.Name, i.k8sName, command)
+		commandWithShell := []string{"/bin/sh", "-c", strings.Join(command, " ")}
+		output, err := k8s.RunCommandInPod(k8s.Namespace(), pod.Name, i.k8sName, commandWithShell)
 		if err != nil {
 			return "", fmt.Errorf("error executing command '%s' in started instance '%s': %v", command, i.k8sName, err)
 		}


### PR DESCRIPTION
To execute commands in the pod with shell-specific syntax like `$?`, we need to use a shell to execute the command. This PR uses the `sh` sell to execute the commands.

<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->

## Checklist

<!-- 
Please complete the checklist to ensure that the PR is ready to be reviewed.

IMPORTANT:
PRs should be left in Draft until the below checklist is completed.
-->

- [ ] New and updated code has appropriate documentation
- [ ] New and updated code has new and/or updated testing
- [ ] Required CI checks are passing
- [ ] Visual proof for any user facing features like CLI or documentation updates
- [ ] Linked issues closed with keywords
