### PR TITLE
refactor: cleanup blank spaces - use funcs multiline 

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,10 +68,11 @@ Simple example:
 
     import (
         "fmt"
-        "github.com/celestiaorg/knuu/pkg/knuu"
         "os"
         "testing"
         "time"
+
+        "github.com/celestiaorg/knuu/pkg/knuu"
     )
 
     func TestMain(m *testing.M) {
@@ -90,10 +91,11 @@ Simple example:
    package main
 
     import (
-        "github.com/celestiaorg/knuu/pkg/knuu"
-        "github.com/stretchr/testify/assert"
         "os"
         "testing"
+
+        "github.com/celestiaorg/knuu/pkg/knuu"
+        "github.com/stretchr/testify/assert"
     )
 
     func TestBasic(t *testing.T) {

--- a/pkg/container/docker.go
+++ b/pkg/container/docker.go
@@ -6,16 +6,17 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"github.com/docker/docker/api/types"
-	"github.com/docker/docker/api/types/container"
-	"github.com/docker/docker/client"
-	"github.com/sirupsen/logrus"
 	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
 	"time"
+
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/client"
+	"github.com/sirupsen/logrus"
 )
 
 // BuilderFactory is responsible for creating new instances of buildah.Builder

--- a/pkg/k8s/k8s.go
+++ b/pkg/k8s/k8s.go
@@ -3,16 +3,26 @@ package k8s
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
+
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
-	"os"
-	"path/filepath"
 )
 
-// Clientset is a global variable that holds a kubernetes clientset.
-var clientset *kubernetes.Clientset
+var (
+	// clientset is a global variable that holds a kubernetes clientset.
+	clientset *kubernetes.Clientset
+
+	// namespacePath path in the filesystem to the namespace name
+	namespacePath = "/var/run/secrets/kubernetes.io/serviceaccount/namespace"
+	// tokenPath path in the filesystem to the service account token
+	tokenPath = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+	// certPath path in the filesystem to the ca.crt
+	certPath = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+)
 
 // Initialize sets up the Kubernetes client with the appropriate configuration.
 func Initialize() error {
@@ -29,7 +39,7 @@ func Initialize() error {
 	// Check if the program is running in a Kubernetes cluster environment
 	if isClusterEnvironment() {
 		// Read the namespace from the pod's spec
-		namespaceBytes, err := os.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace")
+		namespaceBytes, err := os.ReadFile(namespacePath)
 		if err != nil {
 			return fmt.Errorf("reading namespace from pod's spec: %w", err)
 		}
@@ -57,9 +67,6 @@ func Clientset() *kubernetes.Clientset {
 
 // isClusterEnvironment checks if the program is running in a Kubernetes cluster.
 func isClusterEnvironment() bool {
-	tokenPath := "/var/run/secrets/kubernetes.io/serviceaccount/token"
-	certPath := "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
-
 	if _, err := os.Stat(tokenPath); err != nil {
 		return false
 	}

--- a/pkg/k8s/k8s_configmap.go
+++ b/pkg/k8s/k8s_configmap.go
@@ -3,6 +3,7 @@ package k8s
 import (
 	"context"
 	"fmt"
+
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -42,8 +43,12 @@ func ConfigMapExists(namespace, name string) (bool, error) {
 }
 
 // CreateConfigMap creates a configmap
-func CreateConfigMap(namespace, name string, labels map[string]string, data map[string]string) (*v1.ConfigMap, error) {
-
+func CreateConfigMap(
+	namespace,
+	name string,
+	labels,
+	data map[string]string,
+) (*v1.ConfigMap, error) {
 	// check if configmap exists
 	exists, err := ConfigMapExists(namespace, name)
 	if err != nil {
@@ -74,7 +79,6 @@ func CreateConfigMap(namespace, name string, labels map[string]string, data map[
 
 // DeleteConfigMap deletes a configmap
 func DeleteConfigMap(namespace, name string) error {
-
 	// check if configmap exists
 	exists, err := ConfigMapExists(namespace, name)
 	if err != nil {
@@ -99,7 +103,12 @@ func DeleteConfigMap(namespace, name string) error {
 }
 
 // prepareConfigMap prepares a configmap
-func prepareConfigMap(namespace, name string, labels map[string]string, data map[string]string) (*v1.ConfigMap, error) {
+func prepareConfigMap(
+	namespace,
+	name string,
+	labels,
+	data map[string]string,
+) (*v1.ConfigMap, error) {
 	cm := &v1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,

--- a/pkg/k8s/k8s_daemonset.go
+++ b/pkg/k8s/k8s_daemonset.go
@@ -1,12 +1,13 @@
 package k8s
 
 import (
-    "context"
-    "fmt"
-    "github.com/sirupsen/logrus"
-    appv1 "k8s.io/api/apps/v1"
-    v1 "k8s.io/api/core/v1"
-    metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"context"
+	"fmt"
+
+	"github.com/sirupsen/logrus"
+	appv1 "k8s.io/api/apps/v1"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // DaemonSetExists checks if a daemonset exists.
@@ -43,8 +44,13 @@ func GetDaemonSet(namespace, name string) (*appv1.DaemonSet, error) {
 }
 
 // CreateDaemonSet creates a new daemonset.
-func CreateDaemonSet(namespace, name string, labels map[string]string, initContainers []v1.Container, containers []v1.Container) (*appv1.DaemonSet, error) {
-
+func CreateDaemonSet(
+	namespace,
+	name string,
+	labels map[string]string,
+	initContainers []v1.Container,
+	containers []v1.Container,
+) (*appv1.DaemonSet, error) {
 	ds, err := prepareDaemonSet(namespace, name, labels, initContainers, containers)
 	if err != nil {
 		return nil, err
@@ -65,8 +71,13 @@ func CreateDaemonSet(namespace, name string, labels map[string]string, initConta
 }
 
 // UpdateDaemonSet updates an existing daemonset.
-func UpdateDaemonSet(namespace, name string, labels map[string]string, initContainers []v1.Container, containers []v1.Container) (*appv1.DaemonSet, error) {
-
+func UpdateDaemonSet(
+	namespace,
+	name string,
+	labels map[string]string,
+	initContainers []v1.Container,
+	containers []v1.Container,
+) (*appv1.DaemonSet, error) {
 	ds, err := prepareDaemonSet(namespace, name, labels, initContainers, containers)
 	if err != nil {
 		return nil, err
@@ -102,8 +113,13 @@ func DeleteDaemonSet(namespace, name string) error {
 }
 
 // prepareService constructs a new Service object with the specified parameters.
-func prepareDaemonSet(namespace, name string, labels map[string]string, initContainers []v1.Container, containers []v1.Container) (*appv1.DaemonSet, error) {
-
+func prepareDaemonSet(
+	namespace,
+	name string,
+	labels map[string]string,
+	initContainers,
+	containers []v1.Container,
+) (*appv1.DaemonSet, error) {
 	ds := &appv1.DaemonSet{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
@@ -127,5 +143,4 @@ func prepareDaemonSet(namespace, name string, labels map[string]string, initCont
 	}
 
 	return ds, nil
-
 }

--- a/pkg/k8s/k8s_networkpolicy.go
+++ b/pkg/k8s/k8s_networkpolicy.go
@@ -1,14 +1,21 @@
 package k8s
 
 import (
-    "context"
-    "fmt"
-    v1 "k8s.io/api/networking/v1"
-    metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"context"
+	"fmt"
+
+	v1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // CreateNetworkPolicy creates a new NetworkPolicy resource.
-func CreateNetworkPolicy(namespace string, name string, selectorMap map[string]string, ingressSelectorMap map[string]string, egressSelectorMap map[string]string) error {
+func CreateNetworkPolicy(
+	namespace,
+	name string,
+	selectorMap,
+	ingressSelectorMap,
+	egressSelectorMap map[string]string,
+) error {
 	var ingress []v1.NetworkPolicyIngressRule
 	if ingressSelectorMap != nil {
 		ingress = []v1.NetworkPolicyIngressRule{

--- a/pkg/k8s/k8s_pod.go
+++ b/pkg/k8s/k8s_pod.go
@@ -368,7 +368,7 @@ func buildInitContainerCommand(name string, volumes []*Volume) ([]string, error)
 		return []string{}, nil // return empty slice if no volumes are specified
 	}
 
-	var command []string = []string{"sh", "-c"} // initialize the command slice with the required shell interpreter
+	var command = []string{"sh", "-c"} // initialize the command slice with the required shell interpreter
 	for _, volume := range volumes {
 		cmd := fmt.Sprintf("mkdir -p /knuu/%s && cp -r %s/* /knuu/%s && chown -R %d:%d /knuu/*", volume.Path, volume.Path, volume.Path, volume.Owner, volume.Owner)
 		command = append(command, cmd) // add each command to the command slice

--- a/pkg/k8s/k8s_pod.go
+++ b/pkg/k8s/k8s_pod.go
@@ -5,23 +5,22 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"k8s.io/apimachinery/pkg/api/resource"
-	"k8s.io/client-go/tools/portforward"
-	"k8s.io/client-go/transport/spdy"
 	"net/http"
 	"strings"
 	"time"
 
 	"github.com/sirupsen/logrus"
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/tools/portforward"
 	"k8s.io/client-go/tools/remotecommand"
+	"k8s.io/client-go/transport/spdy"
 )
 
 // getPod retrieves a pod from the given namespace and logs any errors.
 func getPod(namespace, name string) (*v1.Pod, error) {
-
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 
@@ -162,7 +161,12 @@ func IsPodRunning(namespace, name string) (bool, error) {
 }
 
 // RunCommandInPod runs a command in a container within a pod.
-func RunCommandInPod(namespace, podName, containerName string, cmd []string) (string, error) {
+func RunCommandInPod(
+	namespace,
+	podName,
+	containerName string,
+	cmd []string,
+) (string, error) {
 	// Get the pod object
 	_, err := getPod(namespace, podName)
 	if err != nil {
@@ -518,7 +522,12 @@ func preparePod(spec PodConfig, init bool) (*v1.Pod, error) {
 }
 
 // PortForwardPod forwards a local port to a port on a pod.
-func PortForwardPod(namespace string, podName string, localPort int, remotePort int) error {
+func PortForwardPod(
+	namespace,
+	podName string,
+	localPort,
+	remotePort int,
+) error {
 	// Get the pod object
 	_, err := getPod(namespace, podName)
 	if err != nil {

--- a/pkg/k8s/k8s_pvc.go
+++ b/pkg/k8s/k8s_pvc.go
@@ -1,16 +1,23 @@
 package k8s
 
 import (
-    "context"
-    "fmt"
-    "github.com/sirupsen/logrus"
-    v1 "k8s.io/api/core/v1"
-    "k8s.io/apimachinery/pkg/api/resource"
-    metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"context"
+	"fmt"
+
+	"github.com/sirupsen/logrus"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // createPersistentVolumeClaim deploys a PersistentVolumeClaim if it does not exist.
-func createPersistentVolumeClaim(namespace, name string, labels map[string]string, size resource.Quantity, accessModes []v1.PersistentVolumeAccessMode) error {
+func createPersistentVolumeClaim(
+	namespace,
+	name string,
+	labels map[string]string,
+	size resource.Quantity,
+	accessModes []v1.PersistentVolumeAccessMode,
+) error {
 	pvc := &v1.PersistentVolumeClaim{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: namespace,
@@ -66,7 +73,6 @@ func deletePersistentVolumeClaim(namespace, name string) error {
 
 // getPersistentVolumeClaim retrieves a PersistentVolumeClaim.
 func getPersistentVolumeClaim(namespace, name string) (*v1.PersistentVolumeClaim, error) {
-
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 

--- a/pkg/k8s/k8s_role.go
+++ b/pkg/k8s/k8s_role.go
@@ -3,13 +3,18 @@ package k8s
 import (
 	"context"
 	"fmt"
+
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // CreateRole creates a role
-func CreateRole(namespace, name string, labels map[string]string, policyRules []rbacv1.PolicyRule) error {
-
+func CreateRole(
+	namespace,
+	name string,
+	labels map[string]string,
+	policyRules []rbacv1.PolicyRule,
+) error {
 	role := &rbacv1.Role{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
@@ -34,7 +39,6 @@ func CreateRole(namespace, name string, labels map[string]string, policyRules []
 
 // DeleteRole deletes a role
 func DeleteRole(namespace, name string) error {
-
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 

--- a/pkg/k8s/k8s_rolebinding.go
+++ b/pkg/k8s/k8s_rolebinding.go
@@ -1,15 +1,21 @@
 package k8s
 
 import (
-    "context"
-    "fmt"
-    rbacv1 "k8s.io/api/rbac/v1"
-    metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"context"
+	"fmt"
+
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // CreateRoleBinding creates a roleBinding
-func CreateRoleBinding(namespace, name string, labels map[string]string, role, serviceAccount string) error {
-
+func CreateRoleBinding(
+	namespace,
+	name string,
+	labels map[string]string,
+	role,
+	serviceAccount string,
+) error {
 	roleBinding := &rbacv1.RoleBinding{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
@@ -44,7 +50,6 @@ func CreateRoleBinding(namespace, name string, labels map[string]string, role, s
 
 // DeleteRoleBinding deletes a roleBinding
 func DeleteRoleBinding(namespace, name string) error {
-
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 

--- a/pkg/k8s/k8s_service.go
+++ b/pkg/k8s/k8s_service.go
@@ -1,13 +1,14 @@
 package k8s
 
 import (
-    "context"
-    "errors"
-    "fmt"
-    "github.com/sirupsen/logrus"
-    v1 "k8s.io/api/core/v1"
-    metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-    "k8s.io/apimachinery/pkg/util/intstr"
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/sirupsen/logrus"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
 // GetService retrieves a service.
@@ -26,8 +27,14 @@ func GetService(namespace, name string) (*v1.Service, error) {
 }
 
 // DeployService deploys a service if it does not exist.
-func DeployService(namespace, name string, labels, selectorMap map[string]string, portsTCP []int, portsUDP []int) (*v1.Service, error) {
-
+func DeployService(
+	namespace,
+	name string,
+	labels,
+	selectorMap map[string]string,
+	portsTCP,
+	portsUDP []int,
+) (*v1.Service, error) {
 	svc, err := prepareService(namespace, name, labels, selectorMap, portsTCP, portsUDP)
 	if err != nil {
 		return nil, fmt.Errorf("error preparing service %s: %w", name, err)
@@ -48,8 +55,14 @@ func DeployService(namespace, name string, labels, selectorMap map[string]string
 }
 
 // PatchService patches an existing service.
-func PatchService(namespace, name string, labels, selectorMap map[string]string, portsTCP, portsUDP []int) error {
-
+func PatchService(
+	namespace,
+	name string,
+	labels,
+	selectorMap map[string]string,
+	portsTCP,
+	portsUDP []int,
+) error {
 	svc, err := prepareService(namespace, name, labels, selectorMap, portsTCP, portsUDP)
 	if err != nil {
 		return fmt.Errorf("error preparing service %s: %w", name, err)
@@ -124,8 +137,15 @@ func buildPorts(tcpPorts, udpPorts []int) []v1.ServicePort {
 }
 
 // prepareService constructs a new Service object with the specified parameters.
-func prepareService(namespace, name string, labels, selectorMap map[string]string,
-	tcpPorts, udpPorts []int) (*v1.Service, error) {
+func prepareService(
+	namespace,
+	name string,
+	labels,
+	selectorMap map[string]string,
+	tcpPorts,
+	udpPorts []int,
+) (*v1.Service, error) {
+
 	if namespace == "" {
 		return nil, errors.New("namespace is required")
 	}

--- a/pkg/k8s/k8s_serviceaccount.go
+++ b/pkg/k8s/k8s_serviceaccount.go
@@ -1,15 +1,15 @@
 package k8s
 
 import (
-    "context"
-    "fmt"
-    v1 "k8s.io/api/core/v1"
-    metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"context"
+	"fmt"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // CreateServiceAccount creates a service account
 func CreateServiceAccount(namespace, name string, labels map[string]string) error {
-
 	serviceAccount := &v1.ServiceAccount{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
@@ -33,7 +33,6 @@ func CreateServiceAccount(namespace, name string, labels map[string]string) erro
 
 // DeleteServiceAccount deletes a service account
 func DeleteServiceAccount(namespace, name string) error {
-
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 

--- a/pkg/k8s/k8s_statefulset.go
+++ b/pkg/k8s/k8s_statefulset.go
@@ -13,13 +13,13 @@ import (
 
 // getStatefulSet retrieves a statefulSet from the given namespace and logs any errors.
 func getStatefulSet(namespace, name string) (*appv1.StatefulSet, error) {
-
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 
 	if !IsInitialized() {
 		return nil, fmt.Errorf("knuu is not initialized")
 	}
+
 	statefulset, err := Clientset().AppsV1().StatefulSets(namespace).Get(ctx, name, metav1.GetOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("failed to get statefulSet %s: %w", name, err)

--- a/pkg/k8s/utils.go
+++ b/pkg/k8s/utils.go
@@ -1,6 +1,8 @@
 package k8s
 
-import "time"
+import (
+	"time"
+)
 
 // namespace is the current namespace in use by the Kubernetes client.
 var namespace = ""

--- a/pkg/knuu/instance.go
+++ b/pkg/knuu/instance.go
@@ -480,14 +480,14 @@ func (i *Instance) Commit() error {
 // AddVolume adds a volume to the instance
 // The owner of the volume is set to 0, if you want to set a custom owner use AddVolumeWithOwner
 // This function can only be called in the states 'Preparing' and 'Committed'
-func (i *Instance) AddVolume(path string, size string) error {
+func (i *Instance) AddVolume(path, size string) error {
 	i.AddVolumeWithOwner(path, size, 0)
 	return nil
 }
 
 // AddVolumeWithOwner adds a volume to the instance with the given owner
 // This function can only be called in the states 'Preparing' and 'Committed'
-func (i *Instance) AddVolumeWithOwner(path string, size string, owner int64) error {
+func (i *Instance) AddVolumeWithOwner(path, size string, owner int64) error {
 	if !i.IsInState(Preparing, Committed) {
 		return fmt.Errorf("adding volume is only allowed in state 'Preparing' or 'Committed'. Current state is '%s'", i.state.String())
 	}
@@ -499,7 +499,7 @@ func (i *Instance) AddVolumeWithOwner(path string, size string, owner int64) err
 
 // SetMemory sets the memory of the instance
 // This function can only be called in the states 'Preparing' and 'Committed'
-func (i *Instance) SetMemory(request string, limit string) error {
+func (i *Instance) SetMemory(request, limit string) error {
 	if !i.IsInState(Preparing, Committed) {
 		return fmt.Errorf("setting memory is only allowed in state 'Preparing' or 'Committed'. Current state is '%s'", i.state.String())
 	}
@@ -522,7 +522,7 @@ func (i *Instance) SetCPU(request string) error {
 
 // SetEnvironmentVariable sets the given environment variable in the instance
 // This function can only be called in the states 'Preparing' and 'Committed'
-func (i *Instance) SetEnvironmentVariable(key string, value string) error {
+func (i *Instance) SetEnvironmentVariable(key, value string) error {
 	if !i.IsInState(Preparing, Committed) {
 		return fmt.Errorf("setting environment variable is only allowed in state 'Preparing' or 'Committed'. Current state is '%s'", i.state.String())
 	}
@@ -708,8 +708,6 @@ func (i *Instance) WaitInstanceIsRunning() error {
 			}
 		}
 	}
-
-	return nil
 }
 
 // DisableNetwork disables the network of the instance

--- a/pkg/knuu/instance_helper.go
+++ b/pkg/knuu/instance_helper.go
@@ -2,15 +2,16 @@ package knuu
 
 import (
 	"fmt"
-	"github.com/celestiaorg/knuu/pkg/k8s"
-	"github.com/google/uuid"
-	"github.com/sirupsen/logrus"
 	"io"
-	"k8s.io/apimachinery/pkg/api/resource"
 	"net"
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/celestiaorg/knuu/pkg/k8s"
+	"github.com/google/uuid"
+	"github.com/sirupsen/logrus"
+	"k8s.io/apimachinery/pkg/api/resource"
 )
 
 // getImageRegistry returns the name of the temporary image registry
@@ -233,7 +234,6 @@ func (i *Instance) destroyVolume() error {
 
 // deployFiles deploys the files for the instance
 func (i *Instance) deployFiles() error {
-
 	data := map[string]string{}
 
 	n := 0
@@ -331,7 +331,7 @@ func (i *Instance) getBuildDir() string {
 }
 
 // validateFileArgs validates the file arguments
-func (i *Instance) validateFileArgs(src string, dest string, chown string) error {
+func (i *Instance) validateFileArgs(src, dest, chown string) error {
 	// check src
 	if src == "" {
 		return fmt.Errorf("src must be set")
@@ -353,7 +353,7 @@ func (i *Instance) validateFileArgs(src string, dest string, chown string) error
 }
 
 // addFileToBuilder adds a file to the builder
-func (i *Instance) addFileToBuilder(src string, dest string, chown string) error {
+func (i *Instance) addFileToBuilder(src, dest, chown string) error {
 	// dest is the same as src here, as we copy the file to the build dir with the subfolder structure of dest
 	err := i.builderFactory.AddToBuilder(dest, dest, chown)
 	if err != nil {

--- a/pkg/knuu/instance_pool.go
+++ b/pkg/knuu/instance_pool.go
@@ -2,6 +2,7 @@ package knuu
 
 import (
 	"fmt"
+
 	"github.com/sirupsen/logrus"
 )
 

--- a/pkg/knuu/knuu.go
+++ b/pkg/knuu/knuu.go
@@ -11,14 +11,15 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 )
 
-// Identifier is the identifier of the current knuu instance
-var identifier string
-var startTime string
-var timeout time.Duration
+var (
+	// identifier is the identifier of the current knuu instance
+	identifier string
+	startTime  string
+	timeout    time.Duration
+)
 
 // Initialize initializes knuug
 func Initialize() error {
-
 	t := time.Now()
 	identifier = fmt.Sprintf("%s_%03d", t.Format("20060102_150405"), t.Nanosecond()/1e6)
 	return InitializeWithIdentifier(identifier)
@@ -60,7 +61,6 @@ func InitializeWithIdentifier(uniqueIdentifier string) error {
 
 	// read timeout from env
 	timeoutString := os.Getenv("KNUU_TIMEOUT")
-
 	if timeoutString == "" {
 		timeout = 60 * time.Minute
 	} else {
@@ -85,7 +85,6 @@ func IsInitialized() bool {
 
 // handleTimeout creates a timeout handler that will delete all resources with the identifier after the timeout
 func handleTimeout() error {
-
 	instance, err := NewInstance("timeout-handler")
 	if err != nil {
 		return fmt.Errorf("cannot create instance: %s", err)

--- a/pkg/knuu/preloader.go
+++ b/pkg/knuu/preloader.go
@@ -2,6 +2,7 @@ package knuu
 
 import (
 	"fmt"
+
 	"github.com/celestiaorg/knuu/pkg/k8s"
 	v1 "k8s.io/api/core/v1"
 )
@@ -89,8 +90,8 @@ func (p *Preloader) preloadImages() error {
 	labels := map[string]string{
 		"app":                          p.k8sName,
 		"k8s.kubernetes.io/managed-by": "knuu",
-		"knuu.sh/test-run-id":                  identifier,
-		"knuu.sh/test-started":                 startTime,
+		"knuu.sh/test-run-id":          identifier,
+		"knuu.sh/test-started":         startTime,
 	}
 
 	exists, err := k8s.DaemonSetExists(k8s.Namespace(), p.k8sName)


### PR DESCRIPTION
hello team! 

This PR contains some refactors, there are no new features on it.

The main changes are:
- Reorder imports, **keeping first the standard library** and then all the others.
- Use **functions multiline**, for better readability, for the functions that we have >3 arguments, I've moved them to multiline.
- Remove some **blank spaces**
- Make the code more consistent with the style

Best! 🚀 

Jose Ramon Mañes