### PR TITLE
chore: increase ttl image life to 24h instead of 1

### DIFF
--- a/pkg/knuu/instance_helper.go
+++ b/pkg/knuu/instance_helper.go
@@ -25,7 +25,7 @@ func (i *Instance) getImageRegistry() (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("error generating UUID: %w", err)
 	}
-	imageName := fmt.Sprintf("ttl.sh/%s:1h", uuid.String())
+	imageName := fmt.Sprintf("ttl.sh/%s:24h", uuid.String())
 	return imageName, nil
 }
 


### PR DESCRIPTION
Not sure but it might be relevant to the failure of BT integration tests after 1 hour