### PR TITLE
Update k8s_pvc.go type "k8s.io/api/core/v1".ResourceRequirements error

### DIFF
--- a/pkg/k8s/k8s_pvc.go
+++ b/pkg/k8s/k8s_pvc.go
@@ -26,7 +26,7 @@ func createPersistentVolumeClaim(
 		},
 		Spec: v1.PersistentVolumeClaimSpec{
 			AccessModes: accessModes,
-			Resources: v1.ResourceRequirements{
+			Resources: v1.VolumeResourceRequirements{
 				Requests: v1.ResourceList{
 					v1.ResourceStorage: size,
 				},


### PR DESCRIPTION
Getting the following error, this PR attempts to fix it:

```sh
/pkg/k8s/k8s_pvc.go:29:15: cannot use v1.ResourceRequirements{…} (value of type "k8s.io/api/core/v1".ResourceRequirements) as "k8s.io/api/core/v1".VolumeResourceRequirements value in struct literal
FAIL	github.com/celestiaorg/knuu-example/basic [build failed]
```
