### PR TITLE
feat: isStarted status check for bittwister

### DIFF
--- a/pkg/knuu/instance.go
+++ b/pkg/knuu/instance.go
@@ -529,12 +529,9 @@ func (i *Instance) AddFolder(src string, dest string, chown string) error {
 		if info.IsDir() {
 			// create directory at destination path
 			return os.MkdirAll(dstPath, os.ModePerm)
-		} else {
-			// copy file to destination path
-			return i.AddFile(path, filepath.Join(dest, relPath), chown)
 		}
-
-		return nil
+		// copy file to destination path
+		return i.AddFile(path, filepath.Join(dest, relPath), chown)
 	})
 
 	if err != nil {


### PR DESCRIPTION
To make sure that the BitTwister sidecar is ready to be used. A new method is added to check that. Sidecar will start with the main instance, but it might take a fraction of a second to have the BitTwister service up and running, so it is advised to check that.

```go
func (c *btConfig) Started() bool
```

and a a blocking check:

```go
func (c *btConfig) WaitForStart(ctx context.Context) error
```
