### PR TITLE
fix(preloader): remove not need import

### DIFF
--- a/pkg/knuu/preloader.go
+++ b/pkg/knuu/preloader.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/celestiaorg/knuu/pkg/k8s"
 	v1 "k8s.io/api/core/v1"
 )
 


### PR DESCRIPTION
hello!

tiny one, just found a non-used import that was breaking the tests.

```
github.com/celestiaorg/knuu@v0.13.3-rc.1/pkg/knuu/preloader.go:7:2: "github.com/celestiaorg/knuu/pkg/k8s" imported and not used
```

cheers!