### PR TITLE
fix: Kaniko builder resource limit

### DIFF
--- a/e2e/basic/build_from_git_test.go
+++ b/e2e/basic/build_from_git_test.go
@@ -27,14 +27,14 @@ func TestBuildFromGit(t *testing.T) {
 	instance, err := knuu.NewInstance("my-instance")
 	require.NoError(t, err, "Error creating instance")
 
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	ctx, cancel := context.WithTimeout(context.Background(), 45*time.Minute)
 	defer cancel()
 
 	// This is a blocking call which builds the image from git repo
 	err = instance.SetGitRepo(ctx, builder.GitContext{
-		Repo:     "https://github.com/celestiaorg/celestia-app.git",
-		Branch:   "main",
-		Commit:   "",
+		Repo:   "https://github.com/celestiaorg/celestia-app.git",
+		Branch: "main",
+		// Commit:   "5ce94f4f010e366df301d25cd5d797c3147ff884",
 		Username: "",
 		Password: "",
 	})

--- a/pkg/builder/kaniko/errors.go
+++ b/pkg/builder/kaniko/errors.go
@@ -45,4 +45,5 @@ var (
 	ErrMinioNotConfigured               = &Error{Code: "MinioNotConfigured", Message: "Minio service is not configured"}
 	ErrMinioDeploymentFailed            = &Error{Code: "MinioDeploymentFailed", Message: "Minio deployment failed"}
 	ErrDeletingMinioContent             = &Error{Code: "DeletingMinioContent", Message: "error deleting Minio content"}
+	ErrParsingQuantity                  = &Error{Code: "ParsingQuantity", Message: "error parsing quantity"}
 )


### PR DESCRIPTION
An issue reported by @rach-id on kaniko build. After investigation, it turned out that it hit the ephemeral storage limit and it seems to be working with `10Gi` when building [Celestia-app](https://github.com/celestiaorg/celestia-app) repo.

This PR suggests a fix to resolve that issue.
More context can be found in [this chat](https://celestia-team.slack.com/archives/C0653SYL6GM/p1715597415962689).

Note: I could not run it on the current version of Robusta as the pod keeps pending for ever to get the resources; tested it on local `minikube`. 