### PR TITLE
chore: refactor batch destroy

### DIFF
--- a/e2e/basic/assert_cleanups.go
+++ b/e2e/basic/assert_cleanups.go
@@ -9,44 +9,35 @@ import (
 
 // assertCleanupInstance is a helper function that cleans up a single instance.
 func assertCleanupInstance(t *testing.T, instance *knuu.Instance) error {
-	if instance != nil {
-		err := instance.Destroy()
-		if err != nil {
-			t.Fatalf("Error destroying instance: %v", err)
-		}
+	if instance == nil {
+		t.Fatal("Instance is nil")
+	}
+
+	if err := instance.Destroy(); err != nil {
+		t.Fatalf("Error destroying instance: %v", err)
 	}
 	return nil
 }
 
 // assertCleanupInstances is a helper function that cleans up a list of instances.
 func assertCleanupInstances(t *testing.T, executor *knuu.Executor, instances []*knuu.Instance) error {
-	if os.Getenv("KNUU_SKIP_CLEANUP") != "true" {
-		err := executor.Destroy()
-		if err != nil {
-			t.Fatalf("Error destroying executor: %v", err)
-		}
-
-		for _, instance := range instances {
-			if instance != nil {
-				err := instance.Destroy()
-				if err != nil {
-					t.Fatalf("Error destroying instance: %v", err)
-				}
-			}
-		}
+	if os.Getenv("KNUU_SKIP_CLEANUP") == "true" {
+		t.Log("Skipping cleanup")
+		return nil
 	}
-	return nil
-}
 
-// BatchDestroy destroys a list of instances.
-func BatchDestroy(instances ...*knuu.Instance) error {
-	for _, instance := range instances {
-		if instance != nil {
-			err := instance.Destroy()
-			if err != nil {
-				return err
-			}
-		}
+	if executor == nil {
+		t.Fatal("Executor is nil")
 	}
+
+	if err := executor.Destroy(); err != nil {
+		t.Fatalf("Error destroying executor: %v", err)
+	}
+
+	err := knuu.BatchDestroy(instances...)
+	if err != nil {
+		t.Fatalf("Error destroying instances: %v", err)
+	}
+
 	return nil
 }

--- a/e2e/basic/basic_test.go
+++ b/e2e/basic/basic_test.go
@@ -1,10 +1,10 @@
 package basic
 
 import (
-	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/celestiaorg/knuu/pkg/knuu"
 )
@@ -31,16 +31,7 @@ func TestBasic(t *testing.T) {
 	}
 
 	t.Cleanup(func() {
-		// Cleanup
-		if os.Getenv("KNUU_SKIP_CLEANUP") == "true" {
-			t.Log("Skipping cleanup")
-			return
-		}
-
-		err = instance.Destroy()
-		if err != nil {
-			t.Fatalf("Error destroying instance: %v", err)
-		}
+		require.NoError(t, knuu.BatchDestroy(instance))
 	})
 
 	// Test logic

--- a/e2e/basic/bittwister_test.go
+++ b/e2e/basic/bittwister_test.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"math"
-	"os"
 	"strconv"
 	"testing"
 	"time"
@@ -50,13 +49,7 @@ func TestBittwister_Bandwidth(t *testing.T) {
 	require.NoError(t, err, "Error cloning instance")
 
 	t.Cleanup(func() {
-		if os.Getenv("KNUU_SKIP_CLEANUP") == "true" {
-			t.Log("Skipping cleanup")
-			return
-		}
-
-		require.NoError(t, iperfServer.Destroy(), "Error destroying iperf-server instance")
-		require.NoError(t, iperfClient.Destroy(), "Error destroying iperf-client instance")
+		require.NoError(t, knuu.BatchDestroy(iperfServer, iperfClient))
 	})
 
 	// Prepare iperf client & server
@@ -190,13 +183,7 @@ func TestBittwister_Packetloss(t *testing.T) {
 	require.NoError(t, err, "Error cloning instance")
 
 	t.Cleanup(func() {
-		if os.Getenv("KNUU_SKIP_CLEANUP") == "true" {
-			t.Log("Skipping cleanup")
-			return
-		}
-
-		require.NoError(t, executor.Destroy(), "Error destroying executor instance")
-		require.NoError(t, target.Destroy(), "Error destroying target instance")
+		require.NoError(t, knuu.BatchDestroy(executor, target))
 	})
 
 	// Prepare ping executor & target
@@ -326,13 +313,7 @@ func TestBittwister_Latency(t *testing.T) {
 	require.NoError(t, err, "Error cloning instance")
 
 	t.Cleanup(func() {
-		if os.Getenv("KNUU_SKIP_CLEANUP") == "true" {
-			t.Log("Skipping cleanup")
-			return
-		}
-
-		require.NoError(t, executor.Destroy(), "Error destroying executor instance")
-		require.NoError(t, target.Destroy(), "Error destroying target instance")
+		require.NoError(t, knuu.BatchDestroy(executor, target))
 	})
 
 	// Prepare ping executor & target
@@ -479,13 +460,7 @@ func TestBittwister_Jitter(t *testing.T) {
 	require.NoError(t, err, "Error cloning instance")
 
 	t.Cleanup(func() {
-		if os.Getenv("KNUU_SKIP_CLEANUP") == "true" {
-			t.Log("Skipping cleanup")
-			return
-		}
-
-		require.NoError(t, executor.Destroy(), "Error destroying executor instance")
-		require.NoError(t, target.Destroy(), "Error destroying target instance")
+		require.NoError(t, knuu.BatchDestroy(executor, target))
 	})
 
 	// Prepare ping executor & target

--- a/e2e/basic/build_from_git_test.go
+++ b/e2e/basic/build_from_git_test.go
@@ -48,12 +48,7 @@ func TestBuildFromGit(t *testing.T) {
 	require.NoError(t, instance.Commit(), "Error committing instance")
 
 	t.Cleanup(func() {
-		if os.Getenv("KNUU_SKIP_CLEANUP") == "true" {
-			t.Log("Skipping cleanup")
-			return
-		}
-
-		require.NoError(t, instance.Destroy(), "Error destroying instance")
+		require.NoError(t, knuu.BatchDestroy(instance))
 	})
 
 	// Test logic

--- a/e2e/basic/env_to_json_test.go
+++ b/e2e/basic/env_to_json_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/celestiaorg/knuu/pkg/knuu"
 )
@@ -81,22 +82,8 @@ func TestEnvToJSON(t *testing.T) {
 	}
 
 	t.Cleanup(func() {
-		// Cleanup
-		if os.Getenv("KNUU_SKIP_CLEANUP") != "true" {
-			err := executor.Destroy()
-			if err != nil {
-				t.Fatalf("Error destroying executor: %v", err)
-			}
-
-			for _, instance := range instances {
-				if instance != nil {
-					err := instance.Destroy()
-					if err != nil {
-						t.Fatalf("Error destroying instance: %v", err)
-					}
-				}
-			}
-		}
+		all := append(instances, executor.Instance)
+		require.NoError(t, knuu.BatchDestroy(all...))
 	})
 
 	// Test logic

--- a/e2e/basic/external_file_test.go
+++ b/e2e/basic/external_file_test.go
@@ -1,11 +1,13 @@
 package basic
 
 import (
-	"github.com/celestiaorg/knuu/pkg/knuu"
-	"github.com/stretchr/testify/assert"
 	"io"
 	"os"
 	"testing"
+
+	"github.com/celestiaorg/knuu/pkg/knuu"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestExternalFile(t *testing.T) {
@@ -66,21 +68,7 @@ func TestExternalFile(t *testing.T) {
 	}
 
 	t.Cleanup(func() {
-		// Cleanup
-		if os.Getenv("KNUU_SKIP_CLEANUP") == "true" {
-			t.Log("Skipping cleanup")
-			return
-		}
-
-		err = executor.Destroy()
-		if err != nil {
-			t.Fatalf("Error destroying executor: %v", err)
-		}
-
-		err = web.Destroy()
-		if err != nil {
-			t.Fatalf("Error destroying instance: %v", err)
-		}
+		require.NoError(t, knuu.BatchDestroy(executor.Instance, web))
 	})
 
 	// Test logic

--- a/e2e/basic/file_test.go
+++ b/e2e/basic/file_test.go
@@ -47,21 +47,7 @@ func TestFile(t *testing.T) {
 	}
 
 	t.Cleanup(func() {
-		// Cleanup
-		if os.Getenv("KNUU_SKIP_CLEANUP") == "true" {
-			t.Log("Skipping cleanup")
-			return
-		}
-
-		err = executor.Destroy()
-		if err != nil {
-			t.Fatalf("Error destroying executor: %v", err)
-		}
-
-		err = web.Destroy()
-		if err != nil {
-			t.Fatalf("Error destroying instance: %v", err)
-		}
+		require.NoError(t, knuu.BatchDestroy(executor.Instance, web))
 	})
 
 	// Test logic
@@ -101,13 +87,7 @@ func TestDownloadFileFromRunningInstance(t *testing.T) {
 	require.NoError(t, target.Start(), "Error starting instance")
 
 	t.Cleanup(func() {
-		// Cleanup
-		if os.Getenv("KNUU_SKIP_CLEANUP") == "true" {
-			t.Log("Skipping cleanup")
-			return
-		}
-
-		require.NoError(t, target.Destroy(), "Error destroying instance")
+		require.NoError(t, knuu.BatchDestroy(target))
 	})
 
 	// Test logic
@@ -137,13 +117,7 @@ func TestMinio(t *testing.T) {
 	require.NoError(t, target.Start(), "Error starting instance")
 
 	t.Cleanup(func() {
-		// Cleanup
-		if os.Getenv("KNUU_SKIP_CLEANUP") == "true" {
-			t.Log("Skipping cleanup")
-			return
-		}
-
-		require.NoError(t, target.Destroy(), "Error destroying instance")
+		require.NoError(t, knuu.BatchDestroy(target))
 	})
 
 	fileContent := "Hello World!"

--- a/e2e/basic/file_test_image_cached_test.go
+++ b/e2e/basic/file_test_image_cached_test.go
@@ -2,7 +2,6 @@ package basic
 
 import (
 	"fmt"
-	"os"
 	"sync"
 	"testing"
 
@@ -66,25 +65,6 @@ func TestFileCached(t *testing.T) {
 		err := assertCleanupInstances(t, executor, instances)
 		if err != nil {
 			t.Fatalf("Error cleaning up: %v", err)
-		}
-	})
-
-	t.Cleanup(func() {
-		// Cleanup
-		if os.Getenv("KNUU_SKIP_CLEANUP") != "true" {
-			err := executor.Destroy()
-			if err != nil {
-				t.Fatalf("Error destroying executor: %v", err)
-			}
-
-			for _, instance := range instances {
-				if instance != nil {
-					err := instance.Destroy()
-					if err != nil {
-						t.Fatalf("Error destroying instance: %v", err)
-					}
-				}
-			}
 		}
 	})
 

--- a/e2e/basic/folder_test.go
+++ b/e2e/basic/folder_test.go
@@ -1,11 +1,11 @@
 package basic
 
 import (
-	"os"
 	"testing"
 
 	"github.com/celestiaorg/knuu/pkg/knuu"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestFolder(t *testing.T) {
@@ -40,21 +40,7 @@ func TestFolder(t *testing.T) {
 	}
 
 	t.Cleanup(func() {
-		// Cleanup
-		if os.Getenv("KNUU_SKIP_CLEANUP") == "true" {
-			t.Log("Skipping cleanup")
-			return
-		}
-
-		err = executor.Destroy()
-		if err != nil {
-			t.Fatalf("Error destroying executor: %v", err)
-		}
-
-		err = web.Destroy()
-		if err != nil {
-			t.Fatalf("Error destroying instance: %v", err)
-		}
+		require.NoError(t, knuu.BatchDestroy(executor.Instance, web))
 	})
 
 	// Test logic

--- a/e2e/basic/probe_test.go
+++ b/e2e/basic/probe_test.go
@@ -1,12 +1,13 @@
 package basic
 
 import (
+	"testing"
+
 	"github.com/celestiaorg/knuu/pkg/knuu"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	"os"
-	"testing"
 )
 
 func TestProbe(t *testing.T) {
@@ -54,21 +55,7 @@ func TestProbe(t *testing.T) {
 	}
 
 	t.Cleanup(func() {
-		// Cleanup
-		if os.Getenv("KNUU_SKIP_CLEANUP") == "true" {
-			t.Log("Skipping cleanup")
-			return
-		}
-
-		err = executor.Destroy()
-		if err != nil {
-			t.Fatalf("Error destroying executor: %v", err)
-		}
-
-		err = web.Destroy()
-		if err != nil {
-			t.Fatalf("Error destroying instance: %v", err)
-		}
+		require.NoError(t, knuu.BatchDestroy(executor.Instance, web))
 	})
 
 	// Test logic

--- a/e2e/basic/rbac_test.go
+++ b/e2e/basic/rbac_test.go
@@ -1,11 +1,12 @@
 package basic
 
 import (
+	"testing"
+
 	"github.com/celestiaorg/knuu/pkg/knuu"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	v1 "k8s.io/api/rbac/v1"
-	"os"
-	"testing"
 )
 
 func TestRBAC(t *testing.T) {
@@ -39,16 +40,7 @@ func TestRBAC(t *testing.T) {
 	}
 
 	t.Cleanup(func() {
-		// Cleanup
-		if os.Getenv("KNUU_SKIP_CLEANUP") == "true" {
-			t.Log("Skipping cleanup")
-			return
-		}
-
-		err = instance.Destroy()
-		if err != nil {
-			t.Fatalf("Error destroying instance: %v", err)
-		}
+		require.NoError(t, knuu.BatchDestroy(instance))
 	})
 
 	// Test logic

--- a/e2e/celestia_app/networking_test.go
+++ b/e2e/celestia_app/networking_test.go
@@ -1,7 +1,6 @@
 package celestia_app
 
 import (
-	"os"
 	"strings"
 	"testing"
 	"time"
@@ -31,25 +30,7 @@ func TestNetworking_DisableNetwork(t *testing.T) {
 	}
 
 	t.Cleanup(func() {
-		// Cleanup
-		if os.Getenv("KNUU_SKIP_CLEANUP") == "true" {
-			t.Log("Skipping cleanup")
-			return
-		}
-
-		err = executor.Destroy()
-		if err != nil {
-			t.Fatalf("Error destroying executor: %v", err)
-		}
-
-		err = validator.Destroy()
-		if err != nil {
-			t.Fatalf("Error destroying instance: %v", err)
-		}
-		err = full.Destroy()
-		if err != nil {
-			t.Fatalf("Error destroying instance: %v", err)
-		}
+		require.NoError(t, knuu.BatchDestroy(executor.Instance, validator, full))
 	})
 
 	// Test logic
@@ -140,25 +121,7 @@ func TestNetworking_SetPacketLossDynamic(t *testing.T) {
 	}
 
 	t.Cleanup(func() {
-		// Cleanup
-		if os.Getenv("KNUU_SKIP_CLEANUP") == "true" {
-			t.Log("Skipping cleanup")
-			return
-		}
-
-		err = executor.Destroy()
-		if err != nil {
-			t.Fatalf("Error destroying executor: %v", err)
-		}
-
-		err = validator.Destroy()
-		if err != nil {
-			t.Fatalf("Error destroying instance: %v", err)
-		}
-		err = full.Destroy()
-		if err != nil {
-			t.Fatalf("Error destroying instance: %v", err)
-		}
+		require.NoError(t, knuu.BatchDestroy(executor.Instance, validator, full))
 	})
 
 	// Test logic

--- a/e2e/celestia_app/stop_test.go
+++ b/e2e/celestia_app/stop_test.go
@@ -1,12 +1,12 @@
 package celestia_app
 
 import (
-	"os"
 	"testing"
 	"time"
 
 	"github.com/celestiaorg/knuu/e2e/celestia_app/utils"
 	"github.com/celestiaorg/knuu/pkg/knuu"
+	"github.com/stretchr/testify/require"
 )
 
 func TestStop(t *testing.T) {
@@ -32,24 +32,7 @@ func TestStop(t *testing.T) {
 	}
 
 	t.Cleanup(func() {
-		// Cleanup
-		if os.Getenv("KNUU_SKIP_CLEANUP") == "true" {
-			t.Log("Skipping cleanup")
-			return
-		}
-
-		err = executor.Destroy()
-		if err != nil {
-			t.Fatalf("Error destroying executor: %v", err)
-		}
-		err = validator.Destroy()
-		if err != nil {
-			t.Fatalf("Error destroying instance: %v", err)
-		}
-		err = full.Destroy()
-		if err != nil {
-			t.Fatalf("Error destroying instance: %v", err)
-		}
+		require.NoError(t, knuu.BatchDestroy(executor.Instance, validator, full))
 	})
 
 	// Test logic

--- a/e2e/celestia_app/upgrade_preloaded_test.go
+++ b/e2e/celestia_app/upgrade_preloaded_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/celestiaorg/knuu/e2e/celestia_app/utils"
 	"github.com/celestiaorg/knuu/pkg/knuu"
+	"github.com/stretchr/testify/require"
 )
 
 var imageToUpgrade = "ghcr.io/celestiaorg/celestia-app:v1.6.0"
@@ -56,16 +57,7 @@ func TestUpgradePreloaded(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Error emptying preloaded images: %v", err)
 		}
-
-		err = executor.Destroy()
-		if err != nil {
-			t.Fatalf("Error destroying executor: %v", err)
-		}
-
-		err = validator.Destroy()
-		if err != nil {
-			t.Fatalf("Error destroying instance: %v", err)
-		}
+		require.NoError(t, knuu.BatchDestroy(executor.Instance, validator))
 	})
 
 	// Test logic

--- a/e2e/celestia_app/upgrade_test.go
+++ b/e2e/celestia_app/upgrade_test.go
@@ -1,11 +1,11 @@
 package celestia_app
 
 import (
-	"os"
 	"testing"
 
 	"github.com/celestiaorg/knuu/e2e/celestia_app/utils"
 	"github.com/celestiaorg/knuu/pkg/knuu"
+	"github.com/stretchr/testify/require"
 )
 
 func TestUpgrade(t *testing.T) {
@@ -27,21 +27,7 @@ func TestUpgrade(t *testing.T) {
 	}
 
 	t.Cleanup(func() {
-		// Cleanup
-		if os.Getenv("KNUU_SKIP_CLEANUP") == "true" {
-			t.Log("Skipping cleanup")
-			return
-		}
-
-		err = executor.Destroy()
-		if err != nil {
-			t.Fatalf("Error destroying executor: %v", err)
-		}
-
-		err = validator.Destroy()
-		if err != nil {
-			t.Fatalf("Error destroying instance: %v", err)
-		}
+		require.NoError(t, knuu.BatchDestroy(executor.Instance, validator))
 	})
 
 	// Test logic

--- a/e2e/celestia_node/basic_test.go
+++ b/e2e/celestia_node/basic_test.go
@@ -2,10 +2,10 @@ package celestia_app
 
 import (
 	"context"
-	"os"
 	"testing"
 
 	"github.com/celestiaorg/knuu/pkg/knuu"
+	"github.com/stretchr/testify/require"
 
 	app_utils "github.com/celestiaorg/knuu/e2e/celestia_app/utils"
 	"github.com/celestiaorg/knuu/e2e/celestia_node/utils"
@@ -36,32 +36,7 @@ func TestBasic(t *testing.T) {
 	light, err := utils.CreateAndStartNode(executor, "light", "light", consensus, full)
 
 	t.Cleanup(func() {
-		// Cleanup
-		if os.Getenv("KNUU_SKIP_CLEANUP") == "true" {
-			t.Log("Skipping cleanup")
-			return
-		}
-
-		err = executor.Destroy()
-		if err != nil {
-			t.Fatalf("Error destroying executor: %v", err)
-		}
-		err = consensus.Destroy()
-		if err != nil {
-			t.Fatalf("Error destroying executor: %v", err)
-		}
-		err = bridge.Destroy()
-		if err != nil {
-			t.Fatalf("Error destroying instance: %v", err)
-		}
-		err = full.Destroy()
-		if err != nil {
-			t.Fatalf("Error destroying instance: %v", err)
-		}
-		err = light.Destroy()
-		if err != nil {
-			t.Fatalf("Error destroying instance: %v", err)
-		}
+		require.NoError(t, knuu.BatchDestroy(executor.Instance, consensus, bridge, full, light))
 	})
 
 	// Test logic

--- a/e2e/celestia_node/otel_test.go
+++ b/e2e/celestia_node/otel_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/celestiaorg/knuu/pkg/knuu"
+	"github.com/stretchr/testify/require"
 
 	app_utils "github.com/celestiaorg/knuu/e2e/celestia_app/utils"
 	"github.com/celestiaorg/knuu/e2e/celestia_node/utils"
@@ -104,32 +105,7 @@ func TestOtel(t *testing.T) {
 	}
 
 	t.Cleanup(func() {
-		// Cleanup
-		if os.Getenv("KNUU_SKIP_CLEANUP") == "true" {
-			t.Log("Skipping cleanup")
-			return
-		}
-
-		err = executor.Destroy()
-		if err != nil {
-			t.Fatalf("Error destroying executor: %v", err)
-		}
-		err = consensus.Destroy()
-		if err != nil {
-			t.Fatalf("Error destroying executor: %v", err)
-		}
-		err = bridge.Destroy()
-		if err != nil {
-			t.Fatalf("Error destroying instance: %v", err)
-		}
-		err = full.Destroy()
-		if err != nil {
-			t.Fatalf("Error destroying instance: %v", err)
-		}
-		err = light.Destroy()
-		if err != nil {
-			t.Fatalf("Error destroying instance: %v", err)
-		}
+		require.NoError(t, knuu.BatchDestroy(executor.Instance, consensus, bridge, full, light))
 	})
 
 	// Test logic

--- a/pkg/knuu/executor.go
+++ b/pkg/knuu/executor.go
@@ -1,11 +1,7 @@
 package knuu
 
-import (
-	"context"
-)
-
 type Executor struct {
-	instances *Instance
+	*Instance
 }
 
 func NewExecutor() (*Executor, error) {
@@ -42,19 +38,17 @@ func NewExecutor() (*Executor, error) {
 	if err != nil {
 		return nil, ErrWaitingInstanceIsRunning.Wrap(err)
 	}
-	return &Executor{
-		instances: instance,
-	}, nil
+	return &Executor{Instance: instance}, nil
 }
 
-func (e *Executor) ExecuteCommand(command ...string) (string, error) {
-	return e.instances.ExecuteCommand(command...)
-}
+// func (e *Executor) ExecuteCommand(command ...string) (string, error) {
+// 	return e.ExecuteCommand(command...)
+// }
 
-func (e *Executor) ExecuteCommandWithContext(ctx context.Context, command ...string) (string, error) {
-	return e.instances.ExecuteCommandWithContext(ctx, command...)
-}
+// func (e *Executor) ExecuteCommandWithContext(ctx context.Context, command ...string) (string, error) {
+// 	return e.ExecuteCommandWithContext(ctx, command...)
+// }
 
-func (e *Executor) Destroy() error {
-	return e.instances.Destroy()
-}
+// func (e *Executor) Destroy() error {
+// 	return e.Destroy()
+// }

--- a/pkg/knuu/instance_destroy.go
+++ b/pkg/knuu/instance_destroy.go
@@ -1,0 +1,63 @@
+package knuu
+
+import (
+	"context"
+	"os"
+
+	"github.com/sirupsen/logrus"
+)
+
+// Destroy destroys the instance
+// This function can only be called in the state 'Started' or 'Destroyed'
+func (i *Instance) Destroy() error {
+	if i.state == Destroyed {
+		return nil
+	}
+
+	if !i.IsInState(Started, Stopped, Destroyed) {
+		return ErrDestroyingNotAllowed.WithParams(i.state.String())
+	}
+
+	// TODO: receive context from the user in the breaking refactor
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	if err := i.destroyPod(ctx); err != nil {
+		return ErrDestroyingPod.WithParams(i.k8sName).Wrap(err)
+	}
+	if err := i.destroyResources(ctx); err != nil {
+		return ErrDestroyingResourcesForInstance.WithParams(i.k8sName).Wrap(err)
+	}
+
+	err := applyFunctionToInstances(i.sidecars, func(sidecar Instance) error {
+		logrus.Debugf("Destroying sidecar resources from '%s'", sidecar.k8sName)
+		return sidecar.destroyResources(ctx)
+	})
+	if err != nil {
+		return ErrDestroyingResourcesForSidecars.WithParams(i.k8sName).Wrap(err)
+	}
+
+	i.state = Destroyed
+	setStateForSidecars(i.sidecars, Destroyed)
+	logrus.Debugf("Set state of instance '%s' to '%s'", i.k8sName, i.state.String())
+
+	return nil
+}
+
+// BatchDestroy destroys a list of instances.
+func BatchDestroy(instances ...*Instance) error {
+	if os.Getenv("KNUU_SKIP_CLEANUP") == "true" {
+		logrus.Info("Skipping cleanup")
+		return nil
+	}
+
+	for _, instance := range instances {
+		if instance == nil {
+			continue
+		}
+		if err := instance.Destroy(); err != nil {
+			return err
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
This PR suggests a refactor for batch destroy instances to have more concise clean up functions in the tests.