### PR TITLE
fix: Stack Overflow in Error Methods

### DIFF
--- a/pkg/builder/docker/errors.go
+++ b/pkg/builder/docker/errors.go
@@ -11,6 +11,10 @@ type Error struct {
 }
 
 func (e *Error) Error() string {
+	if e.Err == e {
+		return e.Message
+	}
+
 	if e.Err != nil {
 		return fmt.Sprintf("%s: %v", e.Message, e.Err)
 	}

--- a/pkg/builder/errors.go
+++ b/pkg/builder/errors.go
@@ -11,6 +11,10 @@ type Error struct {
 }
 
 func (e *Error) Error() string {
+	if e.Err == e {
+		return e.Message
+	}
+
 	if e.Err != nil {
 		return fmt.Sprintf("%s: %v", e.Message, e.Err)
 	}

--- a/pkg/builder/kaniko/errors.go
+++ b/pkg/builder/kaniko/errors.go
@@ -11,6 +11,10 @@ type Error struct {
 }
 
 func (e *Error) Error() string {
+	if e.Err == e {
+		return e.Message
+	}
+
 	if e.Err != nil {
 		return fmt.Sprintf("%s: %v", e.Message, e.Err)
 	}

--- a/pkg/container/errors.go
+++ b/pkg/container/errors.go
@@ -12,6 +12,10 @@ type Error struct {
 }
 
 func (e *Error) Error() string {
+	if e.Err == e {
+		return e.Message
+	}
+
 	msg := fmt.Sprintf(e.Message, e.Params...)
 	if e.Err != nil {
 		return fmt.Sprintf("%s: %v", msg, e.Err)

--- a/pkg/k8s/errors.go
+++ b/pkg/k8s/errors.go
@@ -12,6 +12,10 @@ type Error struct {
 }
 
 func (e *Error) Error() string {
+	if e.Err == e {
+		return e.Message
+	}
+
 	msg := fmt.Sprintf(e.Message, e.Params...)
 	if e.Err != nil {
 		return fmt.Sprintf("%s: %v", msg, e.Err)

--- a/pkg/knuu/errors.go
+++ b/pkg/knuu/errors.go
@@ -12,6 +12,10 @@ type Error struct {
 }
 
 func (e *Error) Error() string {
+	if e.Err == e {
+		return e.Message
+	}
+
 	msg := fmt.Sprintf(e.Message, e.Params...)
 	if e.Err != nil {
 		return fmt.Sprintf("%s: %v", msg, e.Err)

--- a/pkg/minio/errors.go
+++ b/pkg/minio/errors.go
@@ -12,6 +12,10 @@ type Error struct {
 }
 
 func (e *Error) Error() string {
+	if e.Err == e {
+		return e.Message
+	}
+
 	msg := fmt.Sprintf(e.Message, e.Params...)
 	if e.Err != nil {
 		return fmt.Sprintf("%s: %v", msg, e.Err)


### PR DESCRIPTION
This PR addresses a stack overflow issue occurring in the `Error` method of the Error struct in the k8s package. The issue was caused by recursive calls to Error when formatting error messages, leading to infinite recursion and stack overflow.