### PR TITLE
#361 Issue: Update SetLatencyAndJitter func of Go doc

### DIFF
--- a/pkg/knuu/instance.go
+++ b/pkg/knuu/instance.go
@@ -1198,11 +1198,9 @@ func (i *Instance) SetBandwidthLimit(limit int64) error {
 	return nil
 }
 
-// SetLatency sets the latency of the instance
-// latency in ms (e.g. 1000 for 1s)
-// jitter in ms (e.g. 1000 for 1s)
-// Currently, only one of bandwidth, jitter, latency or packet loss can be set
-// This function can only be called in the state 'Commited'
+// SetLatencyAndJitter sets the latency and jitter of an instance in milliseconds (e.g., 1000 for 1 second).
+// Multiple traffic shaping rules like latency, jitter, or packet loss can now be set simultaneously with BitTwister integration.
+// This function can only be called when the instance is in the 'Started' state.
 func (i *Instance) SetLatencyAndJitter(latency, jitter int64) error {
 	if !i.IsInState(Started) {
 		return ErrSettingLatencyJitterNotAllowed.WithParams(i.state.String())

--- a/pkg/knuu/instance.go
+++ b/pkg/knuu/instance.go
@@ -1198,8 +1198,8 @@ func (i *Instance) SetBandwidthLimit(limit int64) error {
 	return nil
 }
 
-// SetLatencyAndJitter sets the latency and jitter of an instance in milliseconds (e.g., 1000 for 1 second).
-// Multiple traffic shaping rules like latency, jitter, or packet loss can now be set simultaneously with BitTwister integration.
+// SetLatencyAndJitter sets both the latency and jitter of an instance in milliseconds (e.g., 1000 for 1 second).
+// With the BitTwister integration, multiple traffic shaping rules like latency and jitter can be set simultaneously.
 // This function can only be called when the instance is in the 'Started' state.
 func (i *Instance) SetLatencyAndJitter(latency, jitter int64) error {
 	if !i.IsInState(Started) {


### PR DESCRIPTION
## Overview

This pull request updates the documentation for the `SetLatencyAndJitter` function in the `knuu` package. The previous documentation was outdated and misleading, indicating that only one traffic shaping rule could be set at a time and the function could only be called in the 'Committed' state. However, with the current BitTwister integration, these limitations have been removed.

The updates include:
- Clarifying that multiple traffic shaping rules such as latency and jitter can now be set simultaneously.
- Specifying that the function can only be called when the instance is in the 'Started' state.

These changes ensure that the documentation accurately reflects the current capabilities and usage requirements of the `SetLatencyAndJitter` function.