### PR TITLE
fix: protobuf v1.3.3 doesn't exist anymore, deleted and refound old v…

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -37,7 +37,7 @@ require (
 	github.com/go-openapi/jsonreference v0.20.2 // indirect
 	github.com/go-openapi/swag v0.22.3 // indirect
 	github.com/goccy/go-json v0.10.2 // indirect
-	github.com/gogo/protobuf v1.3.3 // indirect
+	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/protobuf v1.5.4 // indirect
 	github.com/google/gnostic-models v0.6.8 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect


### PR DESCRIPTION
…ersion

<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->

Closes #392 

Proof
```
-- FAILING 

matt@Carl knuu-test % go get github.com/celestiaorg/knuu
go: downloading github.com/celestiaorg/knuu v0.13.3
go: github.com/celestiaorg/knuu@upgrade (v0.13.3) requires github.com/gogo/protobuf@v1.3.3: reading github.com/gogo/protobuf/go.mod at revision v1.3.3: unknown revision v1.3.3
matt@Carl knuu-test % go get -u github.com/celestiaorg/knuu
go: github.com/celestiaorg/knuu@upgrade (v0.13.3) requires github.com/gogo/protobuf@v1.3.3: reading github.com/gogo/protobuf/go.mod at revision v1.3.3: unknown revision v1.3.3

-- PASSING

matt@Carl knuu-test % go get github.com/celestiaorg/knuu@bd5b9fec4914301325b7d75f9bb062ef95c1d884
go: downloading github.com/celestiaorg/knuu v0.14.0-rc.0.0.20240529135920-bd5b9fec4914
go: upgraded github.com/celestiaorg/bittwister v0.0.0-20231211182706-b065de784c03 => v0.0.0-20231213180407-65cdbaf5b8c7
go: upgraded github.com/celestiaorg/knuu v0.13.1 => v0.14.0-rc.0.0.20240529135920-bd5b9fec4914
go: upgraded github.com/davecgh/go-spew v1.1.1 => v1.1.2-0.20180830191138-d8f796af33cc
go: upgraded github.com/docker/docker v26.0.0+incompatible => v26.1.3+incompatible
go: upgraded github.com/docker/go-connections v0.4.0 => v0.4.1-0.20210727194412-58542c764a11
go: upgraded github.com/imdario/mergo v0.3.6 => v0.3.16
go: upgraded github.com/klauspost/cpuid/v2 v2.2.6 => v2.2.7
go: upgraded github.com/minio/minio-go/v7 v7.0.69 => v7.0.70
go: upgraded github.com/opencontainers/image-spec v1.0.2 => v1.1.0-rc2.0.20221005185240-3a7f492d3f1b
go: upgraded github.com/pmezard/go-difflib v1.0.0 => v1.0.1-0.20181226105442-5d4384ee4fb2
go: upgraded go.uber.org/zap v1.11.0 => v1.27.0
go: upgraded golang.org/x/crypto v0.21.0 => v0.23.0
go: upgraded golang.org/x/exp v0.0.0-20231127185646-65229373498e => v0.0.0-20240213143201-ec583247a57a
go: upgraded golang.org/x/mod v0.14.0 => v0.17.0
go: upgraded golang.org/x/net v0.22.0 => v0.25.0
go: upgraded golang.org/x/term v0.18.0 => v0.20.0
go: upgraded golang.org/x/text v0.14.0 => v0.15.0
go: upgraded golang.org/x/time v0.3.0 => v0.5.0
go: upgraded golang.org/x/tools v0.17.0 => v0.21.0
go: upgraded k8s.io/klog/v2 v2.110.1 => v2.120.1
go: upgraded k8s.io/kube-openapi v0.0.0-20231010175941-2dd684a91f00 => v0.0.0-20240228011516-70dd3763d340
go: upgraded sigs.k8s.io/yaml v1.3.0 => v1.4.0
matt@Carl knuu-test % 
```