### PR TITLE
fix: move defaultLogger to a log directory

### DIFF
--- a/pkg/knuu/knuu.go
+++ b/pkg/knuu/knuu.go
@@ -6,9 +6,6 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
-	"path"
-	"runtime"
-	"strconv"
 	"strings"
 	"syscall"
 	"time"
@@ -21,6 +18,7 @@ import (
 	"github.com/celestiaorg/knuu/pkg/builder/kaniko"
 	"github.com/celestiaorg/knuu/pkg/instance"
 	"github.com/celestiaorg/knuu/pkg/k8s"
+	"github.com/celestiaorg/knuu/pkg/log"
 	"github.com/celestiaorg/knuu/pkg/minio"
 	"github.com/celestiaorg/knuu/pkg/system"
 	"github.com/celestiaorg/knuu/pkg/traefik"
@@ -103,7 +101,7 @@ func New(ctx context.Context, opts ...Option) (*Knuu, error) {
 
 	// handle default values
 	if k.Logger == nil {
-		k.Logger = defaultLogger()
+		k.Logger = log.DefaultLogger()
 	}
 
 	if k.TestScope == "" {
@@ -237,31 +235,4 @@ func (k *Knuu) handleTimeout(ctx context.Context) error {
 	}
 
 	return nil
-}
-
-func defaultLogger() *logrus.Logger {
-	logger := logrus.New()
-
-	logger.SetFormatter(&logrus.TextFormatter{
-		FullTimestamp: true,
-		CallerPrettyfier: func(f *runtime.Frame) (string, string) {
-			filename := path.Base(f.File)
-			directory := path.Base(path.Dir(f.File))
-			return "", directory + "/" + filename + ":" + strconv.Itoa(f.Line)
-		},
-	})
-
-	// Enable reporting the file and line
-	logger.SetReportCaller(true)
-
-	customLevel := os.Getenv("LOG_LEVEL")
-	if customLevel != "" {
-		err := logger.Level.UnmarshalText([]byte(customLevel))
-		if err != nil {
-			logger.Warnf("Failed to parse LOG_LEVEL: %v, defaulting to INFO", err)
-		}
-	}
-	logger.Info("LOG_LEVEL: ", logger.GetLevel())
-
-	return logger
 }

--- a/pkg/log/logger.go
+++ b/pkg/log/logger.go
@@ -1,0 +1,37 @@
+package log
+
+import (
+	"os"
+	"path"
+	"runtime"
+	"strconv"
+
+	"github.com/sirupsen/logrus"
+)
+
+func DefaultLogger() *logrus.Logger {
+	logger := logrus.New()
+
+	logger.SetFormatter(&logrus.TextFormatter{
+		FullTimestamp: true,
+		CallerPrettyfier: func(f *runtime.Frame) (string, string) {
+			filename := path.Base(f.File)
+			directory := path.Base(path.Dir(f.File))
+			return "", directory + "/" + filename + ":" + strconv.Itoa(f.Line)
+		},
+	})
+
+	// Enable reporting the file and line
+	logger.SetReportCaller(true)
+
+	customLevel := os.Getenv("LOG_LEVEL")
+	if customLevel != "" {
+		err := logger.Level.UnmarshalText([]byte(customLevel))
+		if err != nil {
+			logger.Warnf("Failed to parse LOG_LEVEL: %v, defaulting to INFO", err)
+		}
+	}
+	logger.Info("LOG_LEVEL: ", logger.GetLevel())
+
+	return logger
+}


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview
- move the `defaultLogger` function to a log directory and rename `DefaultLogger`
- use `DefaultLogger` from the other packages

issue:
- https://github.com/celestiaorg/knuu/issues/377
<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->
