### PR TITLE
feat(go): bump go to v1.22.4

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/celestiaorg/knuu
 
-go 1.22.3
+go 1.22.4
 
 require (
 	github.com/celestiaorg/bittwister v0.0.0-20231213180407-65cdbaf5b8c7


### PR DESCRIPTION
fixes go standard lib vulnerability: https://github.com/celestiaorg/knuu/issues/424

```go
Vulnerability #1: GO-2024-2887
    Unexpected behavior from Is methods for IPv4-mapped IPv6 addresses in
    net/netip
  More info: https://pkg.go.dev/vuln/GO-2024-2887
  Standard library
    Found in: net/netip@go1.22.3
    Fixed in: net/netip@go1.22.4
    Example traces found:
Error:       #1: pkg/instance/helper.go:398:29: instance.getFreePortTCP calls net.Listen, which eventually calls netip.Addr.IsLoopback
Error:       #2: pkg/instance/helper.go:398:29: instance.getFreePortTCP calls net.Listen, which eventually calls netip.Addr.IsMulticast
Your code is affected by 1 vulnerability from the Go standard library.
This scan also found 0 vulnerabilities in packages you import and 1
vulnerability in modules you require, but your code doesn't appear to call these
vulnerabilities.
Use '-show verbose' for more details.
```