### PR TITLE
apply tshark ip filter and compression options to the tshark insatnce

### DIFF
--- a/e2e/tshark/tshark_test.go
+++ b/e2e/tshark/tshark_test.go
@@ -56,14 +56,14 @@ func TestTshark(t *testing.T) {
 	require.NoError(t, err, "error getting S3 (minio) configs")
 
 	var (
-		filename  = target.K8sName() + instance.TsharkCaptureFileExtension
+		filename  = target.K8sName() + instance.TsharkCaptureFileExtension + ".tar.gz" // compressed file extension
 		keyPrefix = "tshark/" + scope
 		fileKey   = filepath.Join(keyPrefix, filename)
 	)
 
 	err = target.EnableTsharkCollector(
 		instance.TsharkCollectorConfig{
-			VolumeSize:     "10Gi",
+			VolumeSize:     "4Gi",
 			S3AccessKey:    minioConf.AccessKeyID,
 			S3SecretKey:    minioConf.SecretAccessKey,
 			S3Region:       s3Location,
@@ -72,18 +72,13 @@ func TestTshark(t *testing.T) {
 			S3KeyPrefix:    keyPrefix,
 			S3Endpoint:     minioConf.Endpoint,
 			UploadInterval: 1 * time.Second, // for sake of the test we keep this short
+			CompressFiles:  true,
 		},
 	)
 	require.NoError(t, err, "error enabling tshark collector")
 
 	err = target.Commit()
 	require.NoError(t, err, "error committing instance")
-
-	t.Cleanup(func() {
-		if err := kn.CleanUp(ctx); err != nil {
-			t.Logf("error cleaning up knuu: %v", err)
-		}
-	})
 
 	// Test logic
 

--- a/pkg/instance/instance.go
+++ b/pkg/instance/instance.go
@@ -91,6 +91,14 @@ type TsharkCollectorConfig struct {
 
 	// UploadInterval is the interval at which the tshark collector will upload the pcap file to the s3 server
 	UploadInterval time.Duration
+
+	// IpFilter is the ip filter to use for the tshark collector
+	// it trace the incoming/outgoing traffic from/to the specific ip
+	// If not set, it will trace all the traffic
+	IpFilter string
+
+	// CompressFiles is the flag to compress the pcap files before pushing them to s3
+	CompressFiles bool
 }
 
 // SecurityContext represents the security settings for a container

--- a/pkg/instance/tshark.go
+++ b/pkg/instance/tshark.go
@@ -7,7 +7,7 @@ import (
 
 const (
 	tsharkCollectorName        = "tshark-collector"
-	tsharkCollectorImage       = "ghcr.io/celestiaorg/tshark-s3:latest"
+	tsharkCollectorImage       = "ghcr.io/celestiaorg/tshark-s3:pr-17"
 	tsharkCollectorCPU         = "100m"
 	tsharkCollectorMemory      = "250Mi"
 	tsharkCollectorVolumePath  = "/tshark"

--- a/pkg/instance/tshark.go
+++ b/pkg/instance/tshark.go
@@ -7,7 +7,7 @@ import (
 
 const (
 	tsharkCollectorName        = "tshark-collector"
-	tsharkCollectorImage       = "ghcr.io/celestiaorg/tshark-s3:pr-11"
+	tsharkCollectorImage       = "ghcr.io/celestiaorg/tshark-s3:latest"
 	tsharkCollectorCPU         = "100m"
 	tsharkCollectorMemory      = "250Mi"
 	tsharkCollectorVolumePath  = "/tshark"
@@ -23,6 +23,8 @@ const (
 	envStorageEndpoint        = "STORAGE_ENDPOINT"
 	envCaptureFileName        = "CAPTURE_FILE_NAME"
 	envUploadInterval         = "UPLOAD_INTERVAL"
+	envCompressFiles          = "COMPRESS_FILES"
+	envIpFilter               = "IP_FILTER"
 )
 
 func (i *Instance) createTsharkCollectorInstance(ctx context.Context) (*Instance, error) {
@@ -60,6 +62,8 @@ func (i *Instance) createTsharkCollectorInstance(ctx context.Context) (*Instance
 		envStorageEndpoint:        i.tsharkCollectorConfig.S3Endpoint,
 		envUploadInterval:         fmt.Sprintf("%d", int64(i.tsharkCollectorConfig.UploadInterval.Seconds())),
 		envCreateBucket:           fmt.Sprintf("%t", i.tsharkCollectorConfig.CreateBucket),
+		envCompressFiles:          fmt.Sprintf("%t", i.tsharkCollectorConfig.CompressFiles),
+		envIpFilter:               i.tsharkCollectorConfig.IpFilter,
 	}
 
 	for key, value := range envVars {


### PR DESCRIPTION
Since the two options for filtering a particular IP address and enable file compression are added to `tshark-uploader`, this PR proposes a change to add them to the `tshark` instance in `knuu` so the users can configure it based on their needs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added file compression functionality before pushing files to S3.
  - Introduced an IP filter option for more specific data collection.

- **Improvements**
  - Reduced default volume size for `TsharkCollectorConfig` from "10Gi" to "4Gi".
  - Updated `tsharkCollectorImage` to version `pr-17` for improved performance and stability.
  
- **Configuration Updates**
  - New environment variables for customization: `COMPRESS_FILES` and `IP_FILTER`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->