### PR TITLE
chore: bump tshark image version

### DIFF
--- a/pkg/instance/tshark.go
+++ b/pkg/instance/tshark.go
@@ -9,7 +9,7 @@ import (
 
 const (
 	tsharkCollectorName        = "tshark-collector"
-	tsharkCollectorImage       = "ghcr.io/celestiaorg/tshark-s3:pr-17"
+	tsharkCollectorImage       = "ghcr.io/celestiaorg/tshark-s3:pr-20"
 	tsharkCollectorVolumePath  = "/tshark"
 	netAdminCapability         = "NET_ADMIN"
 	TsharkCaptureFileExtension = ".pcapng"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated `tsharkCollectorImage` to the latest version `pr-20` to ensure improved performance and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->