### PR TITLE
fix: sanitize scope

### DIFF
--- a/pkg/knuu/knuu.go
+++ b/pkg/knuu/knuu.go
@@ -49,6 +49,8 @@ type Options struct {
 }
 
 func New(ctx context.Context, opts Options) (*Knuu, error) {
+	opts.TestScope = k8s.SanitizeName(opts.TestScope)
+
 	if err := validateOptions(opts); err != nil {
 		return nil, err
 	}

--- a/pkg/knuu/knuu_old.go
+++ b/pkg/knuu/knuu_old.go
@@ -85,6 +85,8 @@ func InitializeWithScope(testScope string) error {
 		return ErrCannotInitializeKnuu.Wrap(err)
 	}
 
+	testScope = k8s.SanitizeName(testScope)
+
 	tmpKnuu, err = New(ctx, Options{
 		K8sClient:    k8sClient,
 		TestScope:    testScope,

--- a/pkg/knuu/knuu_old.go
+++ b/pkg/knuu/knuu_old.go
@@ -85,8 +85,6 @@ func InitializeWithScope(testScope string) error {
 		return ErrCannotInitializeKnuu.Wrap(err)
 	}
 
-	testScope = k8s.SanitizeName(testScope)
-
 	tmpKnuu, err = New(ctx, Options{
 		K8sClient:    k8sClient,
 		TestScope:    testScope,


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

When initializing knuu with an upper case letter, the `validateOptions` function fails as the scope name is not sanitized correctly.

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the creation process of new `Knuu` instances by sanitizing the `TestScope` field to ensure it meets validation criteria, enhancing stability and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->