### PR TITLE
chore!: refactor Traefik pkg to receive a logger object

### DIFF
--- a/pkg/knuu/knuu.go
+++ b/pkg/knuu/knuu.go
@@ -230,7 +230,8 @@ func setDefaults(ctx context.Context, k *Knuu) error {
 
 func setupProxy(ctx context.Context, k *Knuu) error {
 	k.Proxy = &traefik.Traefik{
-		K8s: k.K8sClient,
+		K8sClient: k.K8sClient,
+		Logger:    k.Logger,
 	}
 	if !k.Proxy.IsTraefikAPIAvailable(ctx) {
 		return ErrTraefikAPINotAvailable


### PR DESCRIPTION
Closes #448 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved the logging capabilities of the app by integrating the `Logger` into the `Traefik` struct.
  - Standardized Kubernetes client references within the `Traefik` struct by renaming `K8s` to `K8sClient`.

- **New Features**
  - Enhanced logging support for `Traefik` operations, providing better monitoring and debugging capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->