### PR TITLE
fix: sanitize name & ns test err

### DIFF
--- a/pkg/k8s/k8s_namespace_test.go
+++ b/pkg/k8s/k8s_namespace_test.go
@@ -228,7 +228,7 @@ func (s *TestSuite) TestNamespaceExists() {
 						})
 			},
 			expectedExist: false,
-			expectedErr:   k8s.ErrGettingNamespace.WithParams("error-namespace").Wrap(errInternalServerError),
+			expectedErr:   errInternalServerError,
 		},
 	}
 

--- a/pkg/knuu/knuu.go
+++ b/pkg/knuu/knuu.go
@@ -49,8 +49,6 @@ type Options struct {
 }
 
 func New(ctx context.Context, opts Options) (*Knuu, error) {
-	opts.TestScope = k8s.SanitizeName(opts.TestScope)
-
 	if err := validateOptions(opts); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
There were two issues causing the tests fail.
1. Sanitize name was called in the begning of knuu.New
2. In the Namespace test, expected error was not updated so caused it to fail

This PR suggest to fix it

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Corrected error handling in namespace existence tests to accurately reflect internal server errors.

- **Refactor**
	- Simplified the initialization process by removing unnecessary sanitization of the `TestScope` field during validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->