### PR TITLE
chore!: set image and set command require a running instance to stop

### DIFF
--- a/pkg/instance/errors.go
+++ b/pkg/instance/errors.go
@@ -83,7 +83,7 @@ var (
 	ErrGettingBuildContext                       = errors.New("GettingBuildContext", "error getting build context")
 	ErrGettingImageName                          = errors.New("GettingImageName", "error getting image name")
 	ErrSettingImageNotAllowedForSidecars         = errors.New("SettingImageNotAllowedForSidecars", "setting image is not allowed for sidecars")
-	ErrSettingCommand                            = errors.New("SettingCommand", "setting command is not allowed in state 'Committed' or 'Started'. Current state is '%s")
+	ErrSettingCommand                            = errors.New("SettingCommand", "setting command is not allowed in state 'Committed' or 'Started	'. Current state is '%s")
 	ErrSettingArgsNotAllowed                     = errors.New("SettingArgsNotAllowed", "setting args is only allowed in state 'Preparing' or 'Committed'. Current state is '%s")
 	ErrAddingPortNotAllowed                      = errors.New("AddingPortNotAllowed", "adding port is only allowed in state 'Preparing' or 'Committed'. Current state is '%s")
 	ErrPortAlreadyRegistered                     = errors.New("PortAlreadyRegistered", "TCP port '%d' is already in registered")

--- a/pkg/instance/errors.go
+++ b/pkg/instance/errors.go
@@ -83,7 +83,7 @@ var (
 	ErrGettingBuildContext                       = errors.New("GettingBuildContext", "error getting build context")
 	ErrGettingImageName                          = errors.New("GettingImageName", "error getting image name")
 	ErrSettingImageNotAllowedForSidecars         = errors.New("SettingImageNotAllowedForSidecars", "setting image is not allowed for sidecars")
-	ErrSettingCommand                            = errors.New("SettingCommand", "setting command is only allowed in state 'Preparing' or 'Committed'. Current state is '%s")
+	ErrSettingCommand                            = errors.New("SettingCommand", "setting command is not allowed in state 'Committed' or 'Started'. Current state is '%s")
 	ErrSettingArgsNotAllowed                     = errors.New("SettingArgsNotAllowed", "setting args is only allowed in state 'Preparing' or 'Committed'. Current state is '%s")
 	ErrAddingPortNotAllowed                      = errors.New("AddingPortNotAllowed", "adding port is only allowed in state 'Preparing' or 'Committed'. Current state is '%s")
 	ErrPortAlreadyRegistered                     = errors.New("PortAlreadyRegistered", "TCP port '%d' is already in registered")

--- a/pkg/instance/helper.go
+++ b/pkg/instance/helper.go
@@ -550,22 +550,6 @@ func (i *Instance) prepareReplicaSetConfig() k8s.ReplicaSetConfig {
 	}
 }
 
-// setImageWithGracePeriod sets the image of the instance with a grace period
-func (i *Instance) setImageWithGracePeriod(ctx context.Context, imageName string, gracePeriod *int64) error {
-	i.imageName = imageName
-
-	_, err := i.K8sClient.ReplaceReplicaSetWithGracePeriod(ctx, i.prepareReplicaSetConfig(), gracePeriod)
-	if err != nil {
-		return ErrReplacingPod.Wrap(err)
-	}
-
-	if err := i.WaitInstanceIsRunning(ctx); err != nil {
-		return ErrWaitingInstanceIsRunning.Wrap(err)
-	}
-
-	return nil
-}
-
 // applyFunctionToInstances applies a function to all instances
 func applyFunctionToInstances(instances []*Instance, function func(sidecar *Instance) error) error {
 	for _, i := range instances {

--- a/pkg/knuu/errors.go
+++ b/pkg/knuu/errors.go
@@ -208,4 +208,5 @@ var (
 	ErrTestScopeNotSet                           = errors.New("TestScopeNotSet", "test scope is not set")
 	ErrK8sClientNotSet                           = errors.New("K8sClientNotSet", "k8s client is not set")
 	ErrTestScopeMistMatch                        = errors.New("TestScopeMistMatch", "test scope '%s' set in options does not match scope '%s' set by the k8sClient namespace")
+	ErrHandleTimeout                             = errors.New("HandleTimeout", "error starting handle timeout")
 )

--- a/pkg/knuu/instance_old.go
+++ b/pkg/knuu/instance_old.go
@@ -73,11 +73,6 @@ func (i *Instance) SetGitRepo(ctx context.Context, gitContext builder.GitContext
 }
 
 // Deprecated: Use the new package knuu instead.
-func (i *Instance) SetImageInstant(image string) error {
-	return i.Instance.SetImageInstant(context.Background(), image)
-}
-
-// Deprecated: Use the new package knuu instead.
 func (i *Instance) SetCommand(command ...string) error {
 	return i.Instance.SetCommand(command...)
 }

--- a/pkg/knuu/knuu.go
+++ b/pkg/knuu/knuu.go
@@ -113,9 +113,6 @@ func (k *Knuu) handleTimeout(ctx context.Context) error {
 	if err := inst.SetImage(ctx, timeoutHandlerImage); err != nil {
 		return ErrCannotSetImage.Wrap(err)
 	}
-	if err := inst.Commit(); err != nil {
-		return ErrCannotCommitInstance.Wrap(err)
-	}
 
 	var commands []string
 
@@ -152,6 +149,9 @@ func (k *Knuu) handleTimeout(ctx context.Context) error {
 
 	if err := inst.AddPolicyRule(rule); err != nil {
 		return ErrCannotAddPolicyRule.Wrap(err)
+	}
+	if err := inst.Commit(); err != nil {
+		return ErrCannotCommitInstance.Wrap(err)
 	}
 	if err := inst.Start(ctx); err != nil {
 		return ErrCannotStartInstance.Wrap(err)

--- a/pkg/knuu/knuu.go
+++ b/pkg/knuu/knuu.go
@@ -49,8 +49,6 @@ type Options struct {
 }
 
 func New(ctx context.Context, opts Options) (*Knuu, error) {
-	opts.TestScope = k8s.SanitizeName(opts.TestScope)
-
 	if err := validateOptions(opts); err != nil {
 		return nil, err
 	}
@@ -79,10 +77,6 @@ func New(ctx context.Context, opts Options) (*Knuu, error) {
 		if err := setupProxy(ctx, k); err != nil {
 			return nil, err
 		}
-	}
-
-	if err := k.handleTimeout(ctx); err != nil {
-		return nil, err
 	}
 
 	return k, nil
@@ -219,6 +213,10 @@ func setDefaults(ctx context.Context, k *Knuu) error {
 		if err != nil {
 			return ErrCannotInitializeK8s.Wrap(err)
 		}
+	}
+
+	if err := k.handleTimeout(ctx); err != nil {
+		return ErrHandleTimeout.Wrap(err)
 	}
 
 	if k.ImageBuilder == nil {


### PR DESCRIPTION
Closes #484 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced error messages for command settings to clarify state restrictions.
	- Streamlined logic for setting images and commands, improving state management.
- **Deprecations**
	- Removed the `SetImageInstant` method and marked the `SetCommand` method as deprecated.
- **Bug Fixes**
	- Improved control flow in the commit operation to ensure logical sequence in policy rule addition.
- **Chores**
	- Removed the `setImageWithGracePeriod` method to simplify instance lifecycle management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->