### PR TITLE
fix: test scope mismatch error

### DIFF
--- a/pkg/knuu/knuu.go
+++ b/pkg/knuu/knuu.go
@@ -172,7 +172,8 @@ func validateOptions(opts Options) error {
 		return ErrK8sClientNotSet
 	}
 
-	if opts.TestScope != "" && opts.K8sClient != nil && opts.TestScope != opts.K8sClient.Namespace() {
+	if opts.TestScope != "" && opts.K8sClient != nil &&
+		k8s.SanitizeName(opts.TestScope) != opts.K8sClient.Namespace() {
 		return ErrTestScopeMistMatch.WithParams(opts.TestScope, opts.K8sClient.Namespace())
 	}
 	return nil


### PR DESCRIPTION
This PR proposes a fix to resolve an error is reported by @cmwaters:

```sh
❯ go run ./test/e2e/benchmark TwoNodeSimple
test-e2e-benchmark2024/07/22 10:49:10 === RUN TwoNodeSimple
test-e2e-benchmark2024/07/22 10:49:10 Running TwoNodeSimple
test-e2e-benchmark2024/07/22 10:49:10 version acf7fc1
{"level":"info","time":"2024-07-22T10:49:10+02:00","message":"Checking Grafana environment variables"}
{"level":"info","time":"2024-07-22T10:49:10+02:00","message":"Grafana environment variables found"}
INFO[0000] Initializing knuu with scope: TwoNodeSimple_20240722_104910 
INFO[2024-07-22T10:49:10+02:00]log/logger.go:37 LOG_LEVEL: info                              
2024/07/22 10:49:34 failed to create benchmark test: cannot initialize knuu: test scope 'TwoNodeSimple_20240722_104910' set in options does not match scope 'twonodesimple-20240722-104910' set by the k8sClient namespace
exit status 1
```

The main issue is that the `namespace` (`scope`) which is coming from the k8s clinet is already passed through the Sanitizer which lowers all the letters, but the validate option in knuu.New does not pass it before check it against it.
This PR adds that to the check.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced enhanced validation for the `TestScope` to ensure it is properly sanitized before comparison, improving robustness against invalid characters or formatting issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->