### PR TITLE
chore: add ctx to the build.Commit() func

### DIFF
--- a/e2e/basic/basic_test.go
+++ b/e2e/basic/basic_test.go
@@ -22,7 +22,7 @@ func (ts *TestSuite) TestBasic() {
 
 	ts.Require().NoError(target.Build().SetImage(ctx, testImage))
 	ts.Require().NoError(target.Build().SetStartCommand("sleep", "infinity"))
-	ts.Require().NoError(target.Build().Commit())
+	ts.Require().NoError(target.Build().Commit(ctx))
 
 	ts.T().Cleanup(func() {
 		if err := target.Execution().Destroy(ctx); err != nil {

--- a/e2e/executor.go
+++ b/e2e/executor.go
@@ -34,7 +34,7 @@ func (e *Executor) NewInstance(ctx context.Context, name string) (*instance.Inst
 		return nil, err
 	}
 
-	if err := i.Build().Commit(); err != nil {
+	if err := i.Build().Commit(ctx); err != nil {
 		return nil, err
 	}
 

--- a/e2e/netshaper/netshaper_test.go
+++ b/e2e/netshaper/netshaper_test.go
@@ -36,7 +36,7 @@ func (s *Suite) TestNetShaperBandwidth() {
 	s.Require().NoError(iperfMother.Build().SetImage(ctx, iperfImage))
 	s.Require().NoError(iperfMother.Build().SetStartCommand("iperf3", "-s"))
 	s.Require().NoError(iperfMother.Network().AddPortTCP(iperfPort))
-	s.Require().NoError(iperfMother.Build().Commit())
+	s.Require().NoError(iperfMother.Build().Commit(ctx))
 
 	iperfServer, err := iperfMother.CloneWithName("iperf-server")
 	s.Require().NoError(err)
@@ -142,7 +142,7 @@ func (s *Suite) TestNetShaperPacketloss() {
 	s.Require().NoError(err)
 
 	s.Require().NoError(mother.Network().AddPortTCP(gopingPort))
-	s.Require().NoError(mother.Build().Commit())
+	s.Require().NoError(mother.Build().Commit(ctx))
 
 	err = mother.Build().SetEnvironmentVariable("SERVE_ADDR", fmt.Sprintf("0.0.0.0:%d", gopingPort))
 	s.Require().NoError(err)
@@ -245,7 +245,7 @@ func (s *Suite) TestNetShaperLatency() {
 	s.Require().NoError(err)
 
 	s.Require().NoError(mother.Network().AddPortTCP(gopingPort))
-	s.Require().NoError(mother.Build().Commit())
+	s.Require().NoError(mother.Build().Commit(ctx))
 
 	err = mother.Build().SetEnvironmentVariable("SERVE_ADDR", fmt.Sprintf("0.0.0.0:%d", gopingPort))
 	s.Require().NoError(err)
@@ -355,7 +355,7 @@ func (s *Suite) TestNetShaperJitter() {
 	s.Require().NoError(err)
 
 	s.Require().NoError(mother.Network().AddPortTCP(gopingPort))
-	s.Require().NoError(mother.Build().Commit())
+	s.Require().NoError(mother.Build().Commit(ctx))
 
 	err = mother.Build().SetEnvironmentVariable("SERVE_ADDR", fmt.Sprintf("0.0.0.0:%d", gopingPort))
 	s.Require().NoError(err)

--- a/e2e/system/build_from_git_test.go
+++ b/e2e/system/build_from_git_test.go
@@ -36,7 +36,7 @@ func (s *Suite) TestBuildFromGit() {
 		}
 	})
 
-	s.Require().NoError(target.Build().Commit())
+	s.Require().NoError(target.Build().Commit(ctx))
 
 	s.T().Logf("Starting instance")
 	s.Require().NoError(target.Execution().Start(ctx))
@@ -74,7 +74,7 @@ func (s *Suite) TestBuildFromGitWithModifications() {
 	err = target.Storage().AddFileBytes([]byte("Hello, world!"), "/home/hello.txt", "root:root")
 	s.Require().NoError(err, "Error adding file")
 
-	s.Require().NoError(target.Build().Commit())
+	s.Require().NoError(target.Build().Commit(ctx))
 
 	s.T().Cleanup(func() {
 		if err := target.Execution().Destroy(ctx); err != nil {

--- a/e2e/system/env_to_json_test.go
+++ b/e2e/system/env_to_json_test.go
@@ -40,7 +40,7 @@ func (s *Suite) TestEnvToJSON() {
 		name := fmt.Sprintf("%s-web%d", namePrefix, i+1)
 
 		ins := s.createNginxInstance(ctx, name)
-		s.Require().NoError(ins.Build().Commit())
+		s.Require().NoError(ins.Build().Commit(ctx))
 		s.Require().NoError(ins.Execution().Start(ctx))
 
 		_, err = ins.Execution().ExecuteCommand(ctx, "mkdir", "-p", nginxHTMLPath)

--- a/e2e/system/external_file_test.go
+++ b/e2e/system/external_file_test.go
@@ -41,7 +41,7 @@ func (s *Suite) TestExternalFile() {
 	err = server.Storage().AddFile(htmlTmpPath, nginxHTMLPath+"/index.html", "0:0")
 	s.Require().NoError(err)
 
-	s.Require().NoError(server.Build().Commit())
+	s.Require().NoError(server.Build().Commit(ctx))
 
 	s.T().Cleanup(func() {
 		err := instance.BatchDestroy(ctx, executor, server)

--- a/e2e/system/file_test.go
+++ b/e2e/system/file_test.go
@@ -26,7 +26,7 @@ func (s *Suite) TestFile() {
 	err = serverfile.Storage().AddFile(resourcesHTML+"/index.html", nginxHTMLPath+"/index.html", "0:0")
 	s.Require().NoError(err)
 
-	s.Require().NoError(serverfile.Build().Commit())
+	s.Require().NoError(serverfile.Build().Commit(ctx))
 
 	s.T().Cleanup(func() {
 		err := instance.BatchDestroy(ctx, serverfile, executor)
@@ -59,7 +59,7 @@ func (s *Suite) TestDownloadFileFromRunningInstance() {
 	ctx := context.Background()
 	s.Require().NoError(target.Build().SetImage(ctx, "alpine:latest"))
 	s.Require().NoError(target.Build().SetArgs("tail", "-f", "/dev/null")) // Keep the container running
-	s.Require().NoError(target.Build().Commit())
+	s.Require().NoError(target.Build().Commit(ctx))
 	s.Require().NoError(target.Execution().Start(ctx))
 
 	s.T().Cleanup(func() {
@@ -98,7 +98,7 @@ func (s *Suite) TestMinio() {
 	ctx := context.Background()
 	s.Require().NoError(target.Build().SetImage(ctx, "alpine:latest"))
 	s.Require().NoError(target.Build().SetArgs("tail", "-f", "/dev/null")) // Keep the container running
-	s.Require().NoError(target.Build().Commit())
+	s.Require().NoError(target.Build().Commit(ctx))
 	s.Require().NoError(target.Execution().Start(ctx))
 
 	s.T().Cleanup(func() {

--- a/e2e/system/file_test_image_cached_test.go
+++ b/e2e/system/file_test_image_cached_test.go
@@ -49,7 +49,7 @@ func (s *Suite) TestFileCached() {
 
 	// Test logic
 	for _, i := range instances {
-		s.Require().NoError(i.Build().Commit())
+		s.Require().NoError(i.Build().Commit(ctx))
 		s.Require().NoError(i.Execution().StartAsync(ctx))
 	}
 

--- a/e2e/system/files_to_volumes_cm_test.go
+++ b/e2e/system/files_to_volumes_cm_test.go
@@ -24,7 +24,7 @@ func (s *Suite) TestNoVolumesNoFiles() {
 	s.Require().NoError(err)
 
 	target := s.createNginxInstance(ctx, namePrefix+"-target")
-	s.Require().NoError(target.Build().Commit())
+	s.Require().NoError(target.Build().Commit(ctx))
 
 	// Cleanup
 	s.T().Cleanup(func() {
@@ -65,7 +65,7 @@ func (s *Suite) TestOneVolumeNoFiles() {
 	err = target.Storage().AddVolumeWithOwner("/opt/vol1", resource.MustParse("1Gi"), 0)
 	s.Require().NoError(err)
 
-	s.Require().NoError(target.Build().Commit())
+	s.Require().NoError(target.Build().Commit(ctx))
 
 	s.T().Cleanup(func() {
 		err := instance.BatchDestroy(ctx, executor, target)
@@ -134,7 +134,7 @@ func (s *Suite) TestNoVolumesOneFile() {
 
 	// Test logic
 	for _, i := range instances {
-		s.Require().NoError(i.Build().Commit())
+		s.Require().NoError(i.Build().Commit(ctx))
 		s.Require().NoError(i.Execution().StartAsync(ctx))
 	}
 
@@ -196,7 +196,7 @@ func (s *Suite) TestOneVolumeOneFile() {
 
 	// Test logic
 	for _, i := range instances {
-		s.Require().NoError(i.Build().Commit())
+		s.Require().NoError(i.Build().Commit(ctx))
 		s.Require().NoError(i.Execution().StartAsync(ctx))
 	}
 
@@ -260,7 +260,7 @@ func (s *Suite) TestOneVolumeTwoFiles() {
 
 	// Test logic
 	for _, i := range instances {
-		s.Require().NoError(i.Build().Commit())
+		s.Require().NoError(i.Build().Commit(ctx))
 		s.Require().NoError(i.Execution().StartAsync(ctx))
 	}
 

--- a/e2e/system/folder_test.go
+++ b/e2e/system/folder_test.go
@@ -21,7 +21,7 @@ func (s *Suite) TestFolder() {
 	err = web.Storage().AddFolder(resourcesHTML, nginxHTMLPath, "0:0")
 	require.NoError(s.T(), err)
 
-	require.NoError(s.T(), web.Build().Commit())
+	require.NoError(s.T(), web.Build().Commit(ctx))
 
 	s.T().Cleanup(func() {
 		err := instance.BatchDestroy(ctx, web, executor)

--- a/e2e/system/folder_test_image_cached_test.go
+++ b/e2e/system/folder_test_image_cached_test.go
@@ -49,7 +49,7 @@ func (s *Suite) TestFolderCached() {
 
 	// Test logic
 	for _, i := range instances {
-		s.Require().NoError(i.Build().Commit())
+		s.Require().NoError(i.Build().Commit(ctx))
 		s.Require().NoError(i.Execution().StartAsync(ctx))
 	}
 

--- a/e2e/system/start_callback_test.go
+++ b/e2e/system/start_callback_test.go
@@ -54,7 +54,7 @@ func TestStartWithCallback(t *testing.T) {
 		}
 	})
 
-	require.NoError(t, target.Build().Commit())
+	require.NoError(t, target.Build().Commit(ctx))
 
 	wg := sync.WaitGroup{}
 	require.NoError(t, target.Execution().StartWithCallback(ctx, func() {

--- a/e2e/tshark/tshark_test.go
+++ b/e2e/tshark/tshark_test.go
@@ -82,7 +82,7 @@ func TestTshark(t *testing.T) {
 		fileKey  = filepath.Join(keyPrefix, filename)
 	)
 
-	require.NoError(t, target.Build().Commit())
+	require.NoError(t, target.Build().Commit(ctx))
 
 	// Test logic
 

--- a/pkg/container/docker.go
+++ b/pkg/container/docker.go
@@ -21,10 +21,6 @@ import (
 	"github.com/celestiaorg/knuu/pkg/builder"
 )
 
-const (
-	DefaultTimeout = 2 * time.Minute
-)
-
 // BuilderFactory is responsible for creating new instances of buildah.Builder
 type BuilderFactory struct {
 	imageNameFrom          string
@@ -166,7 +162,7 @@ func (f *BuilderFactory) Changed() bool {
 
 // PushBuilderImage pushes the image from the given builder to a registry.
 // The image is identified by the provided name.
-func (f *BuilderFactory) PushBuilderImage(imageName string) error {
+func (f *BuilderFactory) PushBuilderImage(ctx context.Context, imageName string) error {
 	if !f.Changed() {
 		logrus.Debugf("No changes made to image %s, skipping push", f.imageNameFrom)
 		return nil
@@ -188,8 +184,6 @@ func (f *BuilderFactory) PushBuilderImage(imageName string) error {
 		return ErrFailedToWriteDockerfile.Wrap(err)
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), DefaultTimeout)
-	defer cancel()
 	logs, err := f.imageBuilder.Build(ctx, &builder.BuilderOptions{
 		ImageName:    f.imageNameTo,
 		Destination:  f.imageNameTo, // in docker the image name and destination are the same

--- a/pkg/instance/build.go
+++ b/pkg/instance/build.go
@@ -131,7 +131,7 @@ func (b *build) SetUser(user string) error {
 
 // Commit commits the instance
 // This function can only be called in the state 'Preparing'
-func (b *build) Commit() error {
+func (b *build) Commit(ctx context.Context) error {
 	if !b.instance.IsState(StatePreparing) {
 		return ErrCommittingNotAllowed.WithParams(b.instance.state.String())
 	}
@@ -163,7 +163,7 @@ func (b *build) Commit() error {
 		b.instance.Logger.Debugf("Using cached image for instance '%s'", b.instance.name)
 	} else {
 		b.instance.Logger.Debugf("Cannot use any cached image for instance '%s'", b.instance.name)
-		err = b.builderFactory.PushBuilderImage(imageName)
+		err = b.builderFactory.PushBuilderImage(ctx, imageName)
 		if err != nil {
 			return ErrPushingImage.WithParams(b.instance.name).Wrap(err)
 		}

--- a/pkg/knuu/instance_old.go
+++ b/pkg/knuu/instance_old.go
@@ -138,7 +138,7 @@ func (i *Instance) SetUser(user string) error {
 
 // Deprecated: Use the new package knuu instead.
 func (i *Instance) Commit() error {
-	return i.Instance.Build().Commit()
+	return i.Instance.Build().Commit(context.Background())
 }
 
 // Deprecated: Use the new package knuu instead.

--- a/pkg/knuu/knuu.go
+++ b/pkg/knuu/knuu.go
@@ -104,7 +104,7 @@ func (k *Knuu) handleTimeout(ctx context.Context) error {
 	if err := inst.Build().SetImage(ctx, timeoutHandlerImage); err != nil {
 		return ErrCannotSetImage.Wrap(err)
 	}
-	if err := inst.Build().Commit(); err != nil {
+	if err := inst.Build().Commit(ctx); err != nil {
 		return ErrCannotCommitInstance.Wrap(err)
 	}
 

--- a/pkg/sidecars/netshaper/netshaper.go
+++ b/pkg/sidecars/netshaper/netshaper.go
@@ -58,7 +58,7 @@ func (bt *NetShaper) Initialize(ctx context.Context, sysDeps system.SystemDepend
 		return ErrAddingBitTwisterPort.Wrap(err)
 	}
 
-	if err := bt.instance.Build().Commit(); err != nil {
+	if err := bt.instance.Build().Commit(ctx); err != nil {
 		return ErrCommittingBitTwisterInstance.Wrap(err)
 	}
 

--- a/pkg/sidecars/observability/obsy.go
+++ b/pkg/sidecars/observability/obsy.go
@@ -110,7 +110,7 @@ func (o *Obsy) Initialize(ctx context.Context, sysDeps system.SystemDependencies
 	if err := o.instance.Resources().SetMemory(otelAgentMemory, otelAgentMemoryLimit); err != nil {
 		return ErrSettingOtelAgentMemory.Wrap(err)
 	}
-	if err := o.instance.Build().Commit(); err != nil {
+	if err := o.instance.Build().Commit(ctx); err != nil {
 		return ErrCommittingOtelAgentInstance.Wrap(err)
 	}
 

--- a/pkg/sidecars/tshark/tshark.go
+++ b/pkg/sidecars/tshark/tshark.go
@@ -84,7 +84,7 @@ func (t *Tshark) Initialize(ctx context.Context, sysDeps system.SystemDependenci
 		return ErrSettingTsharkCollectorImage.Wrap(err)
 	}
 
-	if err := t.instance.Build().Commit(); err != nil {
+	if err := t.instance.Build().Commit(ctx); err != nil {
 		return ErrCommittingTsharkCollectorInstance.Wrap(err)
 	}
 


### PR DESCRIPTION
`build.Commit()` was missing a context to be passed by the user. This PR proposed to have it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced context management in various components, allowing for better cancellation and timeout handling during operations.
  
- **Bug Fixes**
	- Improved robustness and adaptability of the `Commit` method across multiple modules.

- **Refactor**
	- Updated method signatures to include context parameters for improved asynchronous operation management.

- **Tests**
	- Adjusted numerous test functions to align with the new `Commit(ctx)` method signature, ensuring consistent context usage across tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->