### PR TITLE
fix: update configmap if exists

### DIFF
--- a/pkg/k8s/configmap.go
+++ b/pkg/k8s/configmap.go
@@ -44,14 +44,14 @@ func (c *Client) CreateConfigMap(
 
 	cm := prepareConfigMap(c.namespace, name, labels, data)
 	created, err := c.clientset.CoreV1().ConfigMaps(c.namespace).Create(ctx, cm, metav1.CreateOptions{})
-	if err != nil {
-		if !apierrs.IsAlreadyExists(err) {
-			return nil, ErrConfigmapAlreadyExists.WithParams(name).Wrap(err)
-		}
-		return nil, ErrCreatingConfigmap.WithParams(name).Wrap(err)
+	if err == nil {
+		return created, nil
 	}
 
-	return created, nil
+	if apierrs.IsAlreadyExists(err) {
+		return nil, ErrConfigmapAlreadyExists.WithParams(name).Wrap(err)
+	}
+	return nil, ErrCreatingConfigmap.WithParams(name).Wrap(err)
 }
 
 func (c *Client) UpdateConfigMap(
@@ -68,14 +68,14 @@ func (c *Client) UpdateConfigMap(
 
 	cm := prepareConfigMap(c.namespace, name, labels, data)
 	updated, err := c.clientset.CoreV1().ConfigMaps(c.namespace).Update(ctx, cm, metav1.UpdateOptions{})
-	if err != nil {
-		if !apierrs.IsNotFound(err) {
-			return nil, ErrConfigmapDoesNotExist.WithParams(name).Wrap(err)
-		}
-		return nil, ErrUpdatingConfigmap.WithParams(name).Wrap(err)
+	if err == nil {
+		return updated, nil
 	}
 
-	return updated, nil
+	if apierrs.IsNotFound(err) {
+		return nil, ErrConfigmapDoesNotExist.WithParams(name).Wrap(err)
+	}
+	return nil, ErrUpdatingConfigmap.WithParams(name).Wrap(err)
 }
 
 func (c *Client) CreateOrUpdateConfigMap(

--- a/pkg/k8s/errors.go
+++ b/pkg/k8s/errors.go
@@ -136,4 +136,5 @@ var (
 	ErrClientTerminated                = errors.New("ClientTerminated", "terminated by user")
 	ErrListingPods                     = errors.New("ListingPods", "failed to list pods")
 	ErrGetPodStatus                    = errors.New("GetPodStatus", "failed to get pod status for pod %s")
+	ErrUpdatingConfigmap               = errors.New("UpdatingConfigmap", "failed to update configmap %s")
 )

--- a/pkg/k8s/types.go
+++ b/pkg/k8s/types.go
@@ -20,6 +20,7 @@ type KubeManager interface {
 	CreateClusterRole(ctx context.Context, name string, labels map[string]string, policyRules []rbacv1.PolicyRule) error
 	CreateClusterRoleBinding(ctx context.Context, name string, labels map[string]string, clusterRole, serviceAccount string) error
 	CreateConfigMap(ctx context.Context, name string, labels, data map[string]string) (*corev1.ConfigMap, error)
+	CreateOrUpdateConfigMap(ctx context.Context, name string, labels, data map[string]string) (*corev1.ConfigMap, error)
 	CreateCustomResource(ctx context.Context, name string, gvr *schema.GroupVersionResource, obj *map[string]interface{}) error
 	CreateDaemonSet(ctx context.Context, name string, labels map[string]string, initContainers []corev1.Container, containers []corev1.Container) (*appv1.DaemonSet, error)
 	CreateNamespace(ctx context.Context, name string) error
@@ -74,6 +75,7 @@ type KubeManager interface {
 	RunCommandInPod(ctx context.Context, podName, containerName string, cmd []string) (string, error)
 	ConfigMapExists(ctx context.Context, name string) (bool, error)
 	UpdateDaemonSet(ctx context.Context, name string, labels map[string]string, initContainers []corev1.Container, containers []corev1.Container) (*appv1.DaemonSet, error)
+	UpdateConfigMap(ctx context.Context, name string, labels, data map[string]string) (*corev1.ConfigMap, error)
 	WaitForDeployment(ctx context.Context, name string) error
 	WaitForService(ctx context.Context, name string) error
 	Terminate()

--- a/pkg/k8s/validate.go
+++ b/pkg/k8s/validate.go
@@ -276,3 +276,13 @@ func validatePorts(ports []int) error {
 	}
 	return nil
 }
+
+func validateConfigMap(name string, labels, data map[string]string) error {
+	if err := validateConfigMapName(name); err != nil {
+		return err
+	}
+	if err := validateLabels(labels); err != nil {
+		return err
+	}
+	return validateConfigMapKeys(data)
+}


### PR DESCRIPTION
While attempting to upgrade app e2e tests to knuu 0.16.0-rc.0, found out that some of the upgrade tests fail due to existing configmap and the main reason is because we use static names and it is expected to update a resource if it already exists. This PR proposes a change to the configmaps if they already exist which helps the tests pass when an upgrade is happening.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced functionality for managing Kubernetes ConfigMaps with methods to create or update them seamlessly.
	- Introduced validation for ConfigMap parameters to ensure data integrity.
- **Bug Fixes**
	- Improved error handling for ConfigMap updates, providing clearer error messages for failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->