### PR TITLE
chore: add a check for Instance state when cloning

### DIFF
--- a/pkg/instance/errors.go
+++ b/pkg/instance/errors.go
@@ -220,4 +220,5 @@ var (
 	ErrAddingHostToProxyNotAllowed               = errors.New("AddingHostToProxyNotAllowed", "adding host to proxy is only allowed in state 'Started' and 'Preparing'. Current state is '%s'")
 	ErrInstanceNameAlreadyExists                 = errors.New("InstanceNameAlreadyExists", "instance name '%s' already exists")
 	ErrSettingSidecarName                        = errors.New("SettingSidecarName", "error setting sidecar name with prefix '%s' for instance '%s'")
+	ErrCannotCloneInstance                       = errors.New("CannotCloneInstance", "cannot clone instance '%s' in state '%s'")
 )

--- a/pkg/instance/instance.go
+++ b/pkg/instance/instance.go
@@ -141,6 +141,10 @@ func (i *Instance) CloneWithSuffix(suffix string) (*Instance, error) {
 // When cloning an instance that is a sidecar, the clone will be not a sidecar
 // When cloning an instance with sidecars, the sidecars will be cloned as well
 func (i *Instance) CloneWithName(name string) (*Instance, error) {
+	if !i.IsInState(StateCommitted, StateStopped) {
+		return nil, ErrCannotCloneInstance.WithParams(i.name, i.state)
+	}
+
 	clonedSidecars, err := i.sidecars.clone(name)
 	if err != nil {
 		return nil, err

--- a/pkg/instance/instance.go
+++ b/pkg/instance/instance.go
@@ -137,7 +137,7 @@ func (i *Instance) CloneWithSuffix(suffix string) (*Instance, error) {
 }
 
 // CloneWithName creates a clone of the instance with a given name
-// This function can only be called in the state 'Committed'
+// This function can only be called in the state 'Committed' or 'Stopped'
 // When cloning an instance that is a sidecar, the clone will be not a sidecar
 // When cloning an instance with sidecars, the sidecars will be cloned as well
 func (i *Instance) CloneWithName(name string) (*Instance, error) {

--- a/pkg/sidecars/tshark/tshark_test.go
+++ b/pkg/sidecars/tshark/tshark_test.go
@@ -169,7 +169,16 @@ func TestTsharkValidateConfig(t *testing.T) {
 }
 
 func TestTsharkClone(t *testing.T) {
-	testInstance, err := instance.New("testInstance", &system.SystemDependencies{})
+	testInstance, err := instance.New("testInstance",
+		&system.SystemDependencies{
+			Logger: logrus.New(),
+		})
+	require.NoError(t, err)
+
+	err = testInstance.Build().SetImage(context.Background(), "testImage")
+	require.NoError(t, err)
+
+	err = testInstance.Build().Commit(context.Background())
 	require.NoError(t, err)
 
 	tshark := &Tshark{
@@ -184,8 +193,8 @@ func TestTsharkClone(t *testing.T) {
 		UploadInterval: time.Minute * 5,
 		instance:       testInstance,
 	}
-
 	clonePrefixName := "test-clone-prefix"
+
 	clone, err := tshark.Clone(clonePrefixName)
 	require.NoError(t, err)
 


### PR DESCRIPTION
Closes #531 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new error message for cloning instances that are not in an appropriate state.
	- Added validation to ensure instances can only be cloned if they are in the `StateCommitted` or `StateStopped` states.

- **Documentation**
	- Enhanced comments in the cloning method to clarify cloning behavior, especially concerning state requirements.

- **Tests**
	- Improved test cases for the `Tshark` struct by adding a logger and ensuring proper configuration of the test instance before cloning.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->