### PR TITLE
chore: pass a custom logger from user for the builder factory

### DIFF
--- a/pkg/container/docker.go
+++ b/pkg/container/docker.go
@@ -22,20 +22,34 @@ type BuilderFactory struct {
 	dockerFileInstructions []string
 	buildContext           string
 	args                   []builder.ArgInterface
+	logger                 *logrus.Logger
+}
+
+type BuilderFactoryOptions struct {
+	ImageName    string
+	BuildContext string
+	ImageBuilder builder.Builder
+	Args         []builder.ArgInterface
+	Logger       *logrus.Logger
 }
 
 // NewBuilderFactory creates a new instance of BuilderFactory.
-func NewBuilderFactory(imageName, buildContext string, imageBuilder builder.Builder, args []builder.ArgInterface) (*BuilderFactory, error) {
-	if err := os.MkdirAll(buildContext, 0755); err != nil {
+func NewBuilderFactory(opts BuilderFactoryOptions) (*BuilderFactory, error) {
+	if err := verifyOptions(opts); err != nil {
+		return nil, err
+	}
+
+	if err := os.MkdirAll(opts.BuildContext, 0755); err != nil {
 		return nil, ErrFailedToCreateContextDir.Wrap(err)
 	}
 
 	return &BuilderFactory{
-		imageNameFrom:          imageName,
-		dockerFileInstructions: []string{"FROM " + imageName},
-		buildContext:           buildContext,
-		imageBuilder:           imageBuilder,
-		args:                   args,
+		imageNameFrom:          opts.ImageName,
+		dockerFileInstructions: []string{"FROM " + opts.ImageName},
+		buildContext:           opts.BuildContext,
+		imageBuilder:           opts.ImageBuilder,
+		args:                   opts.Args,
+		logger:                 opts.Logger,
 	}, nil
 }
 
@@ -73,7 +87,7 @@ func (f *BuilderFactory) Changed() bool {
 // The image is identified by the provided name.
 func (f *BuilderFactory) PushBuilderImage(ctx context.Context, imageName string) error {
 	if !f.Changed() {
-		logrus.Debugf("No changes made to image %s, skipping push", f.imageNameFrom)
+		f.logger.Debugf("No changes made to image %s, skipping push", f.imageNameFrom)
 		return nil
 	}
 
@@ -101,14 +115,11 @@ func (f *BuilderFactory) PushBuilderImage(ctx context.Context, imageName string)
 		Args:         f.args,
 	})
 
-	qStatus := logrus.TextFormatter{}.DisableQuote
-	logrus.SetFormatter(&logrus.TextFormatter{
-		DisableQuote: true,
-	})
-	logrus.Debug("build logs: ", logs)
-	logrus.SetFormatter(&logrus.TextFormatter{
-		DisableQuote: qStatus,
-	})
+	lf := f.logger.Formatter.(*logrus.TextFormatter)
+	qStatus := lf.DisableQuote
+	lf.DisableQuote = true
+	f.logger.Debug("build logs: ", logs)
+	lf.DisableQuote = qStatus
 
 	return err
 }
@@ -129,7 +140,7 @@ func (f *BuilderFactory) BuildImageFromGitRepo(ctx context.Context, gitCtx build
 		return ErrFailedToGetDefaultCacheOptions.Wrap(err)
 	}
 
-	logrus.Debugf("Building image %s from git repo %s", imageName, gitCtx.Repo)
+	f.logger.Debugf("Building image %s from git repo %s", imageName, gitCtx.Repo)
 
 	logs, err := f.imageBuilder.Build(ctx, &builder.BuilderOptions{
 		ImageName:    imageName,
@@ -139,16 +150,12 @@ func (f *BuilderFactory) BuildImageFromGitRepo(ctx context.Context, gitCtx build
 		Args:         f.args,
 	})
 
-	qStatus := logrus.TextFormatter{}.DisableQuote
-	logrus.SetFormatter(&logrus.TextFormatter{
-		DisableQuote: true,
-	})
+	lf := f.logger.Formatter.(*logrus.TextFormatter)
+	qStatus := lf.DisableQuote
+	lf.DisableQuote = true
+	f.logger.Debug("build logs: ", logs)
+	lf.DisableQuote = qStatus
 
-	logrus.Debug("build logs: ", logs)
-
-	logrus.SetFormatter(&logrus.TextFormatter{
-		DisableQuote: qStatus,
-	})
 	return err
 }
 
@@ -184,7 +191,23 @@ func (f *BuilderFactory) GenerateImageHash() (string, error) {
 		return "", ErrHashingBuildContext.Wrap(err)
 	}
 
-	logrus.Debug("Generated image hash: ", fmt.Sprintf("%x", hasher.Sum(nil)))
+	f.logger.Debug("Generated image hash: ", fmt.Sprintf("%x", hasher.Sum(nil)))
 
 	return fmt.Sprintf("%x", hasher.Sum(nil)), nil
+}
+
+func verifyOptions(opts BuilderFactoryOptions) error {
+	if opts.ImageName == "" {
+		return ErrImageNameEmpty
+	}
+	if opts.BuildContext == "" {
+		return ErrBuildContextEmpty
+	}
+	if opts.ImageBuilder == nil {
+		return ErrImageBuilderEmpty
+	}
+	if opts.Logger == nil {
+		return ErrLoggerEmpty
+	}
+	return nil
 }

--- a/pkg/container/docker.go
+++ b/pkg/container/docker.go
@@ -119,12 +119,7 @@ func (f *BuilderFactory) PushBuilderImage(ctx context.Context, imageName string)
 		Args:         f.args,
 	})
 
-	lf := f.logger.Formatter.(*logrus.TextFormatter)
-	qStatus := lf.DisableQuote
-	lf.DisableQuote = true
-	f.logger.Debug("build logs: ", logs)
-	lf.DisableQuote = qStatus
-
+	f.logDebugWithQuotesDisabled("build logs: ", logs)
 	return err
 }
 
@@ -158,12 +153,7 @@ func (f *BuilderFactory) BuildImageFromGitRepo(ctx context.Context, gitCtx build
 		Args:         f.args,
 	})
 
-	lf := f.logger.Formatter.(*logrus.TextFormatter)
-	qStatus := lf.DisableQuote
-	lf.DisableQuote = true
-	f.logger.Debug("build logs: ", logs)
-	lf.DisableQuote = qStatus
-
+	f.logDebugWithQuotesDisabled("build logs: ", logs)
 	return err
 }
 
@@ -215,4 +205,12 @@ func verifyOptions(opts BuilderFactoryOptions) error {
 		return ErrLoggerEmpty
 	}
 	return nil
+}
+
+func (f *BuilderFactory) logDebugWithQuotesDisabled(args ...interface{}) {
+	lf := f.logger.Formatter.(*logrus.TextFormatter)
+	qStatus := lf.DisableQuote
+	lf.DisableQuote = true
+	f.logger.Debug(args...)
+	lf.DisableQuote = qStatus
 }

--- a/pkg/container/docker.go
+++ b/pkg/container/docker.go
@@ -108,6 +108,10 @@ func (f *BuilderFactory) PushBuilderImage(ctx context.Context, imageName string)
 		return ErrFailedToWriteDockerfile.Wrap(err)
 	}
 
+	if f.imageBuilder == nil {
+		return ErrImageBuilderNotSet
+	}
+
 	logs, err := f.imageBuilder.Build(ctx, &builder.BuilderOptions{
 		ImageName:    f.imageNameTo,
 		Destination:  f.imageNameTo, // in docker the image name and destination are the same
@@ -141,6 +145,10 @@ func (f *BuilderFactory) BuildImageFromGitRepo(ctx context.Context, gitCtx build
 	}
 
 	f.logger.Debugf("Building image %s from git repo %s", imageName, gitCtx.Repo)
+
+	if f.imageBuilder == nil {
+		return ErrImageBuilderNotSet
+	}
 
 	logs, err := f.imageBuilder.Build(ctx, &builder.BuilderOptions{
 		ImageName:    imageName,
@@ -202,9 +210,6 @@ func verifyOptions(opts BuilderFactoryOptions) error {
 	}
 	if opts.BuildContext == "" {
 		return ErrBuildContextEmpty
-	}
-	if opts.ImageBuilder == nil {
-		return ErrImageBuilderEmpty
 	}
 	if opts.Logger == nil {
 		return ErrLoggerEmpty

--- a/pkg/container/errors.go
+++ b/pkg/container/errors.go
@@ -27,6 +27,6 @@ var (
 	ErrHashingBuildContext            = errors.New("HashingBuildContext", "error hashing build context")
 	ErrImageNameEmpty                 = errors.New("ImageNameEmpty", "image name is empty")
 	ErrBuildContextEmpty              = errors.New("BuildContextEmpty", "build context is empty")
-	ErrImageBuilderEmpty              = errors.New("ImageBuilderEmpty", "image builder is empty")
+	ErrImageBuilderNotSet             = errors.New("ImageBuilderNotSet", "image builder is not set")
 	ErrLoggerEmpty                    = errors.New("LoggerEmpty", "logger is empty")
 )

--- a/pkg/container/errors.go
+++ b/pkg/container/errors.go
@@ -25,4 +25,8 @@ var (
 	ErrReadingFile                    = errors.New("ReadingFile", "error reading file: %s")
 	ErrHashingFile                    = errors.New("HashingFile", "error hashing file %s")
 	ErrHashingBuildContext            = errors.New("HashingBuildContext", "error hashing build context")
+	ErrImageNameEmpty                 = errors.New("ImageNameEmpty", "image name is empty")
+	ErrBuildContextEmpty              = errors.New("BuildContextEmpty", "build context is empty")
+	ErrImageBuilderEmpty              = errors.New("ImageBuilderEmpty", "image builder is empty")
+	ErrLoggerEmpty                    = errors.New("LoggerEmpty", "logger is empty")
 )

--- a/pkg/instance/build.go
+++ b/pkg/instance/build.go
@@ -54,7 +54,13 @@ func (b *build) SetImage(ctx context.Context, image string, args ...builder.ArgI
 	}
 
 	// Use the builder to build a new image
-	factory, err := container.NewBuilderFactory(image, b.getBuildDir(), b.instance.ImageBuilder, args)
+	factory, err := container.NewBuilderFactory(container.BuilderFactoryOptions{
+		ImageName:    image,
+		BuildContext: b.getBuildDir(),
+		ImageBuilder: b.instance.ImageBuilder,
+		Args:         args,
+		Logger:       b.instance.Logger,
+	})
 	if err != nil {
 		return ErrCreatingBuilder.Wrap(err)
 	}
@@ -80,7 +86,13 @@ func (b *build) SetGitRepo(ctx context.Context, gitContext builder.GitContext, a
 		return ErrGettingImageName.Wrap(err)
 	}
 
-	factory, err := container.NewBuilderFactory(imageName, b.getBuildDir(), b.instance.ImageBuilder, args)
+	factory, err := container.NewBuilderFactory(container.BuilderFactoryOptions{
+		ImageName:    imageName,
+		BuildContext: b.getBuildDir(),
+		ImageBuilder: b.instance.ImageBuilder,
+		Args:         args,
+		Logger:       b.instance.Logger,
+	})
 	if err != nil {
 		return ErrCreatingBuilder.Wrap(err)
 	}


### PR DESCRIPTION
Closes #538 

local tests are passing and the debug logs of the builder is shown when the debug level is set:
```sh
=== RUN   TestRunSuite
time="2024-10-08T16:53:15+03:30" level=info msg="Current log level" file="log/logger.go:41" env_log_level=LOG_LEVEL log_level=debug
time="2024-10-08T16:53:15+03:30" level=debug msg="set state of instance" file="instance/state.go:41" instance=timeout-handler state=Preparing
time="2024-10-08T16:53:15+03:30" level=debug msg="no need to build and push image for instance" file="instance/build.go:164" image="docker.io/bitnami/kubectl:latest" instance=timeout-handler
time="2024-10-08T16:53:15+03:30" level=debug msg="set state of instance" file="instance/state.go:41" instance=timeout-handler state=Committed
time="2024-10-08T16:53:15+03:30" level=debug msg="the namespace will be deleted" file="knuu/knuu.go:140" namespace=20241008-165248-541
time="2024-10-08T16:53:16+03:30" level=debug msg="started statefulSet" file="instance/execution.go:337" instance=timeout-handler
time="2024-10-08T16:53:16+03:30" level=debug msg="set state of instance" file="instance/state.go:41" instance=timeout-handler state=Started
time="2024-10-08T16:53:23+03:30" level=debug msg="Service created successfully." file="traefik/traefik.go:259" service=traefik
time="2024-10-08T16:53:36+03:30" level=debug msg="proxy endpoint" file="knuu/knuu.go:237" endpoint="151.115.12.124:80"
    suite_setup_test.go:53: Scope: 20241008-165248-541
=== RUN   TestRunSuite/TestBuildFromGit
=== PAUSE TestRunSuite/TestBuildFromGit
=== RUN   TestRunSuite/TestBuildFromGitWithModifications
=== PAUSE TestRunSuite/TestBuildFromGitWithModifications
=== CONT  TestRunSuite/TestBuildFromGit
=== CONT  TestRunSuite/TestBuildFromGitWithModifications
    build_image_test.go:22: Creating new instance
    build_image_test.go:26: Building the image
    build_image_test.go:64: Creating new instance
    build_image_test.go:68: Setting git repo
time="2024-10-08T16:53:36+03:30" level=debug msg="set state of instance" file="instance/state.go:41" instance=build-from-git state=Preparing
time="2024-10-08T16:53:36+03:30" level=debug msg="Building image ttl.sh/bb7a5c161d9535a225a7fa67e665b4d8305204a82bff3c75cb925cf578f20b7e:24h from git repo github.com/celestiaorg/knuu" file="container/docker.go:143"
time="2024-10-08T16:53:36+03:30" level=debug msg="set state of instance" file="instance/state.go:41" instance=build-from-git-with-modifications state=Preparing
time="2024-10-08T16:53:36+03:30" level=debug msg="Building image ttl.sh/bb7a5c161d9535a225a7fa67e665b4d8305204a82bff3c75cb925cf578f20b7e:24h from git repo github.com/celestiaorg/knuu" file="container/docker.go:143"
time=2024-10-08T16:53:54+03:30 level=debug msg=build logs: Enumerating objects: 2995, done.
Counting objects: 100% (1676/1676), done.
Compressing objects: 100% (904/904), done.
Total 2995 (delta 1265), reused 895 (delta 764), pack-reused 1319 (from 1)
INFO[0002] Retrieving image manifest ubuntu:18.04       
INFO[0002] Retrieving image ubuntu:18.04 from registry index.docker.io 
INFO[0003] Retrieving image manifest ubuntu:18.04       
INFO[0003] Returning cached image manifest              
INFO[0003] Built cross stage deps: map[]                
INFO[0003] Retrieving image manifest ubuntu:18.04       
INFO[0003] Returning cached image manifest              
INFO[0003] Retrieving image manifest ubuntu:18.04       
INFO[0003] Returning cached image manifest              
INFO[0003] Executing 0 build triggers                   
INFO[0003] Building stage 'ubuntu:18.04' [idx: '0', base-idx: '-1'] 
INFO[0003] Checking for cached layer ttl.sh/bb7a5c161d9535a225a7fa67e665b4d8305204a82bff3c75cb925cf578f20b7e:24h:d9ec0812facda4186859133fdf2d9fdff77bd1feaf4bf75effde8c60df58c240... 
INFO[0003] No cached layer found for cmd RUN echo "${MESSAGE}" > /test.txt 
INFO[0003] Unpacking rootfs as cmd RUN echo "${MESSAGE}" > /test.txt requires it. 
INFO[0004] ARG MESSAGE="Hello, World!"                  
INFO[0004] No files changed in this command, skipping snapshotting. 
INFO[0004] RUN echo "${MESSAGE}" > /test.txt            
INFO[0004] Initializing snapshotter ...                 
INFO[0004] Taking snapshot of full filesystem...        
INFO[0005] Cmd: /bin/sh                                 
INFO[0005] Args: [-c echo "${MESSAGE}" > /test.txt]     
INFO[0005] Running: [/bin/sh -c echo "${MESSAGE}" > /test.txt] 
INFO[0005] Taking snapshot of full filesystem...        
INFO[0005] Pushing layer ttl.sh/bb7a5c161d9535a225a7fa67e665b4d8305204a82bff3c75cb925cf578f20b7e:24h:d9ec0812facda4186859133fdf2d9fdff77bd1feaf4bf75effde8c60df58c240 to cache now 
INFO[0005] CMD ["sleep", "infinity"]                    
INFO[0005] No files changed in this command, skipping snapshotting. 
WARN[0005] Error uploading layer to cache: getting tag for destination: repository can only contain the characters `abcdefghijklmnopqrstuvwxyz0123456789_-./`: bb7a5c161d9535a225a7fa67e665b4d8305204a82bff3c75cb925cf578f20b7e:24h 
INFO[0005] Pushing image to ttl.sh/bb7a5c161d9535a225a7fa67e665b4d8305204a82bff3c75cb925cf578f20b7e:24h 
INFO[0012] Pushed ttl.sh/bb7a5c161d9535a225a7fa67e665b4d8305204a82bff3c75cb925cf578f20b7e@sha256:decb5331e1940ad72de02fa4b0816ec13cb7f98f9d0ca905e6ff41412a509fa6 
 file=container/docker.go:156
    build_image_test.go:36: Image built
time="2024-10-08T16:53:54+03:30" level=debug msg="no need to build and push image for instance" file="instance/build.go:164" image="ttl.sh/bb7a5c161d9535a225a7fa67e665b4d8305204a82bff3c75cb925cf578f20b7e:24h" instance=build-from-git
time="2024-10-08T16:53:54+03:30" level=debug msg="build logs: Enumerating objects: 2995, done.\nCounting objects:   0% (1/1641)\rCounting objects:   1% (17/1641)\rCounting objects:   2% (33/1641)\rCounting objects:   3% (50/1641)\rCounting objects:   4% (66/1641)\rCounting objects:   5% (83/1641)\rCounting objects:   6% (99/1641)\rCounting objects:   7% (115/1641)\rCounting objects:   8% (132/1641)\rCounting objects:   9% (148/1641)\rCounting objects:  10% (165/1641)\rCounting objects:  11% (181/1641)\rCounting objects:  12% (197/1641)\rCounting objects:  13% (214/1641)\rCounting objects:  14% (230/1641)\rCounting objects:  15% (247/1641)\rCounting objects:  16% (263/1641)\rCounting objects:  17% (279/1641)\rCounting objects:  18% (296/1641)\rCounting objects:  19% (312/1641)\rCounting objects:  20% (329/1641)\rCounting objects:  21% (345/1641)\rCounting objects:  22% (362/1641)\rCounting objects:  23% (378/1641)\rCounting objects:  24% (394/1641)\rCounting objects:  25% (411/1641)\rCounting objects:  26% (427/1641)\rCounting objects:  27% (444/1641)\rCounting objects:  28% (460/1641)\rCounting objects:  29% (476/1641)\rCounting objects:  30% (493/1641)\rCounting objects:  31% (509/1641)\rCounting objects:  32% (526/1641)\rCounting objects:  33% (542/1641)\rCounting objects:  34% (558/1641)\rCounting objects:  35% (575/1641)\rCounting objects:  36% (591/1641)\rCounting objects:  37% (608/1641)\rCounting objects:  38% (624/1641)\rCounting objects:  39% (640/1641)\rCounting objects:  40% (657/1641)\rCounting objects:  41% (673/1641)\rCounting objects:  42% (690/1641)\rCounting objects:  43% (706/1641)\rCounting objects:  44% (723/1641)\rCounting objects:  45% (739/1641)\rCounting objects:  46% (755/1641)\rCounting objects:  47% (772/1641)\rCounting objects:  48% (788/1641)\rCounting objects:  49% (805/1641)\rCounting objects:  50% (821/1641)\rCounting objects:  51% (837/1641)\rCounting objects:  52% (854/1641)\rCounting objects:  53% (870/1641)\rCounting objects:  54% (887/1641)\rCounting objects:  55% (903/1641)\rCounting objects:  56% (919/1641)\rCounting objects:  57% (936/1641)\rCounting objects:  58% (952/1641)\rCounting objects:  59% (969/1641)\rCounting objects:  60% (985/1641)\rCounting objects:  61% (1002/1641)\rCounting objects:  62% (1018/1641)\rCounting objects:  63% (1034/1641)\rCounting objects:  64% (1051/1641)\rCounting objects:  65% (1067/1641)\rCounting objects:  66% (1084/1641)\rCounting objects:  67% (1100/1641)\rCounting objects:  68% (1116/1641)\rCounting objects:  69% (1133/1641)\rCounting objects:  70% (1149/1641)\rCounting objects:  71% (1166/1641)\rCounting objects:  72% (1182/1641)\rCounting objects:  73% (1198/1641)\rCounting objects:  74% (1215/1641)\rCounting objects:  75% (1231/1641)\rCounting objects:  76% (1248/1641)\rCounting objects:  77% (1264/1641)\rCounting objects:  78% (1280/1641)\rCounting objects:  79% (1297/1641)\rCounting objects:  80% (1313/1641)\rCounting objects:  81% (1330/1641)\rCounting objects:  82% (1346/1641)\rCounting objects:  83% (1363/1641)\rCounting objects:  84% (1379/1641)\rCounting objects:  85% (1395/1641)\rCounting objects:  86% (1412/1641)\rCounting objects:  87% (1428/1641)\rCounting objects:  88% (1445/1641)\rCounting objects:  89% (1461/1641)\rCounting objects:  90% (1477/1641)\rCounting objects:  91% (1494/1641)\rCounting objects:  92% (1510/1641)\rCounting objects:  93% (1527/1641)\rCounting objects:  94% (1543/1641)\rCounting objects:  95% (1559/1641)\rCounting objects:  96% (1576/1641)\rCounting objects:  97% (1592/1641)\rCounting objects:  98% (1609/1641)\rCounting objects:  99% (1625/1641)\rCounting objects: 100% (1641/1641)\rCounting objects: 100% (1641/1641), done.\nCompressing objects:   0% (1/900)\rCompressing objects:   1% (9/900)\rCompressing objects:   2% (18/900)\rCompressing objects:   3% (27/900)\rCompressing objects:   4% (36/900)\rCompressing objects:   5% (45/900)\rCompressing objects:   6% (54/900)\rCompressing objects:   7% (63/900)\rCompressing objects:   8% (72/900)\rCompressing objects:   9% (81/900)\rCompressing objects:  10% (90/900)\rCompressing objects:  11% (99/900)\rCompressing objects:  12% (108/900)\rCompressing objects:  13% (117/900)\rCompressing objects:  14% (126/900)\rCompressing objects:  15% (135/900)\rCompressing objects:  16% (144/900)\rCompressing objects:  17% (153/900)\rCompressing objects:  18% (162/900)\rCompressing objects:  19% (171/900)\rCompressing objects:  20% (180/900)\rCompressing objects:  21% (189/900)\rCompressing objects:  22% (198/900)\rCompressing objects:  23% (207/900)\rCompressing objects:  24% (216/900)\rCompressing objects:  25% (225/900)\rCompressing objects:  26% (234/900)\rCompressing objects:  27% (243/900)\rCompressing objects:  28% (252/900)\rCompressing objects:  29% (261/900)\rCompressing objects:  30% (270/900)\rCompressing objects:  31% (279/900)\rCompressing objects:  32% (288/900)\rCompressing objects:  33% (297/900)\rCompressing objects:  34% (306/900)\rCompressing objects:  35% (315/900)\rCompressing objects:  36% (324/900)\rCompressing objects:  37% (333/900)\rCompressing objects:  38% (342/900)\rCompressing objects:  39% (351/900)\rCompressing objects:  40% (360/900)\rCompressing objects:  41% (369/900)\rCompressing objects:  42% (378/900)\rCompressing objects:  43% (387/900)\rCompressing objects:  44% (396/900)\rCompressing objects:  45% (405/900)\rCompressing objects:  46% (414/900)\rCompressing objects:  47% (423/900)\rCompressing objects:  48% (432/900)\rCompressing objects:  49% (441/900)\rCompressing objects:  50% (450/900)\rCompressing objects:  51% (459/900)\rCompressing objects:  52% (468/900)\rCompressing objects:  53% (477/900)\rCompressing objects:  54% (486/900)\rCompressing objects:  55% (495/900)\rCompressing objects:  56% (504/900)\rCompressing objects:  57% (513/900)\rCompressing objects:  58% (522/900)\rCompressing objects:  59% (531/900)\rCompressing objects:  60% (540/900)\rCompressing objects:  61% (549/900)\rCompressing objects:  62% (558/900)\rCompressing objects:  63% (567/900)\rCompressing objects:  64% (576/900)\rCompressing objects:  65% (585/900)\rCompressing objects:  66% (594/900)\rCompressing objects:  67% (603/900)\rCompressing objects:  68% (612/900)\rCompressing objects:  69% (621/900)\rCompressing objects:  70% (630/900)\rCompressing objects:  71% (639/900)\rCompressing objects:  72% (648/900)\rCompressing objects:  73% (657/900)\rCompressing objects:  74% (666/900)\rCompressing objects:  75% (675/900)\rCompressing objects:  76% (684/900)\rCompressing objects:  77% (693/900)\rCompressing objects:  78% (702/900)\rCompressing objects:  79% (711/900)\rCompressing objects:  80% (720/900)\rCompressing objects:  81% (729/900)\rCompressing objects:  82% (738/900)\rCompressing objects:  83% (747/900)\rCompressing objects:  84% (756/900)\rCompressing objects:  85% (765/900)\rCompressing objects:  86% (774/900)\rCompressing objects:  87% (783/900)\rCompressing objects:  88% (792/900)\rCompressing objects:  89% (801/900)\rCompressing objects:  90% (810/900)\rCompressing objects:  91% (819/900)\rCompressing objects:  92% (828/900)\rCompressing objects:  93% (837/900)\rCompressing objects:  94% (846/900)\rCompressing objects:  95% (855/900)\rCompressing objects:  96% (864/900)\rCompressing objects:  97% (873/900)\rCompressing objects:  98% (882/900)\rCompressing objects:  99% (891/900)\rCompressing objects: 100% (900/900)\rCompressing objects: 100% (900/900), done.\nTotal 2995 (delta 1229), reused 864 (delta 733), pack-reused 1354 (from 1)\n\x1b[36mINFO\x1b[0m[0002] Retrieving image manifest ubuntu:18.04       \n\x1b[36mINFO\x1b[0m[0002] Retrieving image ubuntu:18.04 from registry index.docker.io \n\x1b[36mINFO\x1b[0m[0003] Retrieving image manifest ubuntu:18.04       \n\x1b[36mINFO\x1b[0m[0003] Returning cached image manifest              \n\x1b[36mINFO\x1b[0m[0003] Built cross stage deps: map[]                \n\x1b[36mINFO\x1b[0m[0003] Retrieving image manifest ubuntu:18.04       \n\x1b[36mINFO\x1b[0m[0003] Returning cached image manifest              \n\x1b[36mINFO\x1b[0m[0003] Retrieving image manifest ubuntu:18.04       \n\x1b[36mINFO\x1b[0m[0003] Returning cached image manifest              \n\x1b[36mINFO\x1b[0m[0003] Executing 0 build triggers                   \n\x1b[36mINFO\x1b[0m[0003] Building stage 'ubuntu:18.04' [idx: '0', base-idx: '-1'] \n\x1b[36mINFO\x1b[0m[0003] Checking for cached layer ttl.sh/bb7a5c161d9535a225a7fa67e665b4d8305204a82bff3c75cb925cf578f20b7e:24h:d9ec0812facda4186859133fdf2d9fdff77bd1feaf4bf75effde8c60df58c240... \n\x1b[36mINFO\x1b[0m[0003] No cached layer found for cmd RUN echo \"${MESSAGE}\" > /test.txt \n\x1b[36mINFO\x1b[0m[0003] Unpacking rootfs as cmd RUN echo \"${MESSAGE}\" > /test.txt requires it. \n\x1b[36mINFO\x1b[0m[0004] ARG MESSAGE=\"Hello, World!\"                  \n\x1b[36mINFO\x1b[0m[0004] No files changed in this command, skipping snapshotting. \n\x1b[36mINFO\x1b[0m[0004] RUN echo \"${MESSAGE}\" > /test.txt            \n\x1b[36mINFO\x1b[0m[0004] Initializing snapshotter ...                 \n\x1b[36mINFO\x1b[0m[0004] Taking snapshot of full filesystem...        \n\x1b[36mINFO\x1b[0m[0005] Cmd: /bin/sh                                 \n\x1b[36mINFO\x1b[0m[0005] Args: [-c echo \"${MESSAGE}\" > /test.txt]     \n\x1b[36mINFO\x1b[0m[0005] Running: [/bin/sh -c echo \"${MESSAGE}\" > /test.txt] \n\x1b[36mINFO\x1b[0m[0005] Taking snapshot of full filesystem...        \n\x1b[36mINFO\x1b[0m[0005] CMD [\"sleep\", \"infinity\"]                    \n\x1b[36mINFO\x1b[0m[0005] Pushing layer ttl.sh/bb7a5c161d9535a225a7fa67e665b4d8305204a82bff3c75cb925cf578f20b7e:24h:d9ec0812facda4186859133fdf2d9fdff77bd1feaf4bf75effde8c60df58c240 to cache now \n\x1b[36mINFO\x1b[0m[0005] No files changed in this command, skipping snapshotting. \n\x1b[33mWARN\x1b[0m[0005] Error uploading layer to cache: getting tag for destination: repository can only contain the characters `abcdefghijklmnopqrstuvwxyz0123456789_-./`: bb7a5c161d9535a225a7fa67e665b4d8305204a82bff3c75cb925cf578f20b7e:24h \n\x1b[36mINFO\x1b[0m[0005] Pushing image to ttl.sh/bb7a5c161d9535a225a7fa67e665b4d8305204a82bff3c75cb925cf578f20b7e:24h \n\x1b[36mINFO\x1b[0m[0013] Pushed ttl.sh/bb7a5c161d9535a225a7fa67e665b4d8305204a82bff3c75cb925cf578f20b7e@sha256:47b88f416c7038d8a7b39df32fa8d37f2fe94a4254fc28a2c6f6f980a76cee2d \n" file="container/docker.go:156"
time=2024-10-08T16:53:54+03:30 level=debug msg=set state of instance file=instance/state.go:41 instance=build-from-git state=Committed
    build_image_test.go:40: Starting instance
time=2024-10-08T16:53:54+03:30 level=debug msg=Generated image hash: 84a72f66837481462173d732f39d6b7705af88ead95b52d12b9dc8be93af9d01 file=container/docker.go:194
time=2024-10-08T16:53:54+03:30 level=debug msg=cannot use any cached image for instance file=instance/build.go:197 instance=build-from-git-with-modifications
time=2024-10-08T16:53:55+03:30 level=debug msg=started statefulSet file=instance/execution.go:337 instance=build-from-git
time=2024-10-08T16:53:55+03:30 level=debug msg=set state of instance file=instance/state.go:41 instance=build-from-git state=Started
    build_image_test.go:43: Instance started
    build_image_test.go:45: Getting file bytes
time=2024-10-08T16:54:14+03:30 level=debug msg=build logs: INFO[0001] Retrieving image manifest ttl.sh/bb7a5c161d9535a225a7fa67e665b4d8305204a82bff3c75cb925cf578f20b7e:24h 
INFO[0001] Retrieving image ttl.sh/bb7a5c161d9535a225a7fa67e665b4d8305204a82bff3c75cb925cf578f20b7e:24h from registry ttl.sh 
INFO[0002] Built cross stage deps: map[]                
INFO[0002] Retrieving image manifest ttl.sh/bb7a5c161d9535a225a7fa67e665b4d8305204a82bff3c75cb925cf578f20b7e:24h 
INFO[0002] Returning cached image manifest              
INFO[0002] Executing 0 build triggers                   
INFO[0002] Building stage 'ttl.sh/bb7a5c161d9535a225a7fa67e665b4d8305204a82bff3c75cb925cf578f20b7e:24h' [idx: '0', base-idx: '-1'] 
INFO[0002] Unpacking rootfs as cmd ADD --chown=root:root /home/hello.txt /home/hello.txt requires it. 
INFO[0004] Using files from context: [/kaniko/buildcontext/home/hello.txt] 
INFO[0004] ADD --chown=root:root /home/hello.txt /home/hello.txt 
INFO[0004] Taking snapshot of files...                  
INFO[0004] Pushing image to ttl.sh/84a72f66837481462173d732f39d6b7705af88ead95b52d12b9dc8be93af9d01:24h 
INFO[0009] Pushed ttl.sh/84a72f66837481462173d732f39d6b7705af88ead95b52d12b9dc8be93af9d01@sha256:95f7db225468fcce2b3753622b2752b7ad0228a2053dcb7392ba9a6e41c7fa13 
 file=container/docker.go:121
time=2024-10-08T16:54:14+03:30 level=debug msg=pushed new image for instance file=instance/build.go:208 image=ttl.sh/84a72f66837481462173d732f39d6b7705af88ead95b52d12b9dc8be93af9d01:24h instance=build-from-git-with-modifications
time=2024-10-08T16:54:14+03:30 level=debug msg=set state of instance file=instance/state.go:41 instance=build-from-git-with-modifications state=Committed
time=2024-10-08T16:54:15+03:30 level=debug msg=started statefulSet file=instance/execution.go:337 instance=build-from-git-with-modifications
time=2024-10-08T16:54:15+03:30 level=debug msg=set state of instance file=instance/state.go:41 instance=build-from-git-with-modifications state=Started
=== NAME  TestRunSuite
    suite.go:59: Cleaning up knuu...
    suite.go:63: Knuu is cleaned up
--- PASS: TestRunSuite (47.82s)
    --- PASS: TestRunSuite/TestBuildFromGit (26.41s)
    --- PASS: TestRunSuite/TestBuildFromGitWithModifications (46.72s)
PASS
ok  	github.com/celestiaorg/knuu/e2e/system	94.574s
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced logging capabilities in the BuilderFactory structure.
	- Introduced a new structured format for BuilderFactory options.

- **Bug Fixes**
	- Added specific error messages for empty fields related to image and build context management.

- **Refactor**
	- Updated methods to utilize the new BuilderFactoryOptions struct for improved parameter handling.
	- Refactored the instantiation of the BuilderFactory in the SetImage and SetGitRepo methods.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->