### PR TITLE
fix: obsy prometheus exporter

### DIFF
--- a/pkg/sidecars/observability/otel.go
+++ b/pkg/sidecars/observability/otel.go
@@ -343,7 +343,7 @@ func (o *Obsy) createExporters() Exporters {
 		exporters.Jaeger = o.createJaegerExporter()
 	}
 
-	if o.obsyConfig.prometheusEndpointPort != 0 {
+	if o.obsyConfig.prometheusExporterEndpoint != "" {
 		exporters.Prometheus = o.createPrometheusExporter()
 	}
 


### PR DESCRIPTION
There was a bug that I was trying to find and the culprit is in the obsy sidecar. It prevented to set Prometheus as an exporter in the Otel collector. This PR proposes a fix for that.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new telemetry configuration feature for enhanced observability.
	- Added support for Prometheus exporter configuration validation.

- **Bug Fixes**
	- Improved logic for creating the Prometheus exporter based on updated configuration checks.

- **Documentation**
	- Updated documentation to reflect changes in telemetry and exporter configuration handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->